### PR TITLE
Fix add_pivot

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -40,20 +40,20 @@ function symgraph_factorizing_permutation(
             end
             Xₐ = X ∩ S
             isempty(Xₐ) && continue
-            X = X \ Xₐ
-            isempty(X) && continue
-            P[i] = X
+            Xₙ = X \ Xₐ
+            isempty(Xₙ) && continue
+            P[i] = Xₙ
             insert!(P, i + between, Xₐ)
-            add_pivot(X, Xₐ)
+            add_pivot(X, Xₐ, Xₙ)
             i += 1
         end
     end
 
-    function add_pivot(X, Xₐ)
+    function add_pivot(X, Xₐ, Xₙ)
         if X in pivots
             push!(pivots, Xₐ)
         else
-            S, L = smaller_larger(X, Xₐ)
+            S, L = smaller_larger(Xₐ, Xₙ)
             push!(pivots, S)
             i = findfirst(isequal(X), modules)
             if i !== nothing


### PR DESCRIPTION
Before the fix, the condition `X in pivots` in the function add_pivot is never true and `i = findfirst(isequal(X), modules)` is always `nothing`.  This did not affect the correctness of the algorithm.

The corresponding paper uses records instead of values for the parts. The record for the old part X becomes the record for the new part X \ S  (see last paragraph page 152 [HPV99]).  These changes result in a more faithful adoption of the algorithm.

[HPV99] M. Habib, C. Paul, and L. Viennot, “Partition refinement techniques: an interesting algorithmic tool kit”