### PR TITLE
Compute overlap components in linear time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,4 +5,3 @@ version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ of directed graphs using algorithms from the following papers:
 * McConnell & Montgolfier 2004: _"Linear-time modular decomposition of directed graphs"_
 * Habib & Paul 2009: _"A survey on algorithmic aspects of modular decomposition"_
 
-The implementation as it currently stands is not linear time for fairly silly reasons. Specifically,
-I used a brute force algorithm for computing the overlap components of two strong module trees; a
-linear time algorithm exists, as described in Dalhaus 1998, "Parallel algorithms for hierarchical
-clustering and applications to split decomposition and parity graph recognition", but I didn't
-bother to implement it. There are also parts of strong module tree construction from a factorizing
-permutation that may be super-linear unnecessarily.
-
 The strong module tree construction code uses an efficient and novel (to me at least) approach to
 manipulating trees: instead of building tree data structures explicitly, since the tree operations
 always keep the leaves in the same order, it works with counts of how many open and close

--- a/bench/overlap_scaling.jl
+++ b/bench/overlap_scaling.jl
@@ -1,0 +1,232 @@
+# Empirical check that OverlapComponents runs in time linear in the size of its
+# input, n + Σ|X|. Too slow for the standard test suite, so it lives here:
+#
+#     julia bench/overlap_scaling.jl               # wall clock scaling
+#     julia bench/overlap_scaling.jl --instructions # retired instruction counts
+#
+# The module has no dependencies, so this needs no project environment.
+#
+# The wall clock tables report time per unit of input, which is flat iff the
+# implementation is linear, and the log-log slope of time against input size,
+# which is 1.0 iff it is linear. At these sizes the working set outgrows every
+# level of cache, so measured time keeps a memory hierarchy ramp in it that no
+# amount of algorithmic linearity removes; expect slopes a little above 1.
+#
+# The --instructions mode settles that ambiguity where perf(1) is available.
+# Retired instructions are unaffected by cache misses -- a miss costs cycles,
+# not instructions -- so instructions per unit of input is flat exactly when the
+# work is linear. Each measurement runs the algorithm once and again five times
+# in a fresh process and takes the difference, which cancels out interpreter
+# startup, compilation and building the input family.
+
+include(joinpath(@__DIR__, "..", "src", "OverlapComponents.jl"))
+using .OverlapComponents
+using Printf, Random, Statistics
+
+## family shapes, each parameterized by a single size knob ##
+
+# a star: every set meets set 1 and nothing else, so the overlap graph has
+# Θ(m²) edges while the input has only 2m. The case Dahlhaus' detour exists for.
+star(s) = (s, [[1, i] for i = 2:s])
+
+# a chain of sliding windows: a single overlap class spanning everything
+windows(s, w=8) = (s, [collect(i:i+w-1) for i = 1:s-w])
+
+# random fixed size subsets: many classes, many near misses
+function random_sets(s, k=8)
+    rng = MersenneTwister(s)
+    (s, map(1:s) do _
+        X = Int[]
+        while length(X) < min(k, s)
+            v = rand(rng, 1:s)
+            v in X || push!(X, v)
+        end
+        sort!(X)
+    end)
+end
+
+# a nested chain: laminar, nothing overlaps anything, but Σ|X| is quadratic in
+# the ground set -- so this shape scales the input size without scaling n
+nested(s) = (s, [collect(1:i) for i = 1:s])
+
+# two balanced hierarchies over one ground set: the shape that modular
+# decomposition of a digraph actually feeds to overlap components
+function hierarchy(V, out=Vector{Int}[])
+    push!(out, V)
+    length(V) > 1 || return out
+    k = length(V) ÷ 2
+    hierarchy(V[1:k], out)
+    hierarchy(V[k+1:end], out)
+    return out
+end
+
+function two_trees(s)
+    rng = MersenneTwister(s)
+    (s, [hierarchy(randperm(rng, s)); hierarchy(randperm(rng, s))])
+end
+
+# ladders chosen so that the largest input in each shape is a few million
+const SHAPES = [
+    ("star (Θ(m²) overlap graph edges)", star,        [1, 2, 4, 8, 16, 32] .* 10^5),
+    ("sliding windows",                  windows,     [1, 2, 4, 8, 16, 32] .* 10^5),
+    ("random 8-element subsets",         random_sets, [25, 50, 100, 200, 400, 800] .* 10^3),
+    ("nested chain (Σ|X| = Θ(n²))",      nested,      [750, 1500, 3000, 6000, 12000]),
+    ("two balanced hierarchies",         two_trees,   [25, 50, 100, 200, 400] .* 10^3),
+]
+
+shape_named(name) = only(s for (_, s, _) in SHAPES if string(s) == name)
+
+## the quadratic baseline this replaced ##
+
+function pairwise_components(F::Vector{Vector{Int}})
+    m = length(F)
+    S = map(sort, F)
+    class, nclasses = zeros(Int, m), 0
+    for i = 1:m
+        class[i] == 0 || continue
+        nclasses += 1
+        stack = [i]
+        while !isempty(stack)
+            x = pop!(stack)
+            class[x] == 0 || continue
+            class[x] = nclasses
+            for j = 1:m
+                class[j] == 0 && overlap(S[x], S[j]) && push!(stack, j)
+            end
+        end
+    end
+    U = [Int[] for _ = 1:nclasses]
+    for (i, X) in enumerate(F)
+        append!(U[class[i]], X)
+    end
+    return sort!(map(sort!∘unique!, U))
+end
+
+## wall clock scaling ##
+
+function best_time(f, args...; trials=5)
+    f(args...) # warm up and compile
+    minimum(1:trials) do _
+        GC.gc()
+        @elapsed f(args...)
+    end
+end
+
+# least squares slope of log(y) against log(x): 1.0 means linear
+function fitted_exponent(x, y)
+    lx, ly = log.(x), log.(y)
+    sum((lx .- mean(lx)) .* (ly .- mean(ly))) / sum((lx .- mean(lx)).^2)
+end
+
+function report(name, shape, scales)
+    @printf("\n%s\n", name)
+    @printf("  %10s %12s %12s %10s %9s %7s\n",
+            "n", "sets", "input size", "time", "ns/input", "slope")
+    sizes, times, previous = Float64[], Float64[], nothing
+    for s in scales
+        n, F = shape(s)
+        N = n + sum(length, F)
+        t = best_time(overlap_components, F, n)
+        push!(sizes, N); push!(times, t)
+        slope = previous === nothing ? NaN :
+            log(t / previous[2]) / log(N / previous[1])
+        @printf("  %10d %12d %12d %10.4fs %9.1f %7s\n", n, length(F), N, t,
+                1e9t / N, isnan(slope) ? "-" : @sprintf("%.2f", slope))
+        flush(stdout)
+        previous = (N, t)
+    end
+    @printf("  fitted exponent over the whole ladder: %.2f\n",
+            fitted_exponent(sizes, times))
+    flush(stdout)
+end
+
+function crossover(shape, scales)
+    @printf("\nstar: linear vs quadratic\n")
+    @printf("  %10s %12s %12s %12s %10s\n",
+            "n", "input size", "Dahlhaus", "pairwise", "speedup")
+    for s in scales
+        n, F = shape(s)
+        N = n + sum(length, F)
+        fast = best_time(overlap_components, F, n)
+        slow = best_time(pairwise_components, F, trials=1)
+        @printf("  %10d %12d %11.4fs %11.4fs %9.0fx\n", n, N, fast, slow, slow/fast)
+        flush(stdout)
+    end
+end
+
+function verify()
+    print("verifying against the pairwise baseline ... ")
+    for (name, shape, _) in SHAPES, s in (50, 100, 200)
+        n, F = shape(s)
+        sort(overlap_components(F, n)) == pairwise_components(F) ||
+            error("mismatch on $name at scale $s")
+    end
+    println("ok")
+    flush(stdout)
+end
+
+## retired instruction counts, via perf(1) ##
+
+# run the algorithm `reps` times on one family and report nothing: this process
+# is measured from the outside
+function run_only(name, size, reps)
+    n, F = shape_named(name)(size)
+    total = 0
+    for _ = 1:reps
+        total += length(overlap_components(F, n))
+    end
+    total > 0 || error("no components")
+end
+
+function perf_instructions(name, size, reps)
+    self = joinpath(@__DIR__, basename(@__FILE__))
+    out = read(pipeline(`perf stat -x, -e instructions --
+                         $(Base.julia_cmd()) $self --run $name $size $reps`,
+                        stderr = `cat`), String)
+    for line in split(out, '\n')
+        fields = split(line, ',')
+        length(fields) ≥ 3 && fields[3] == "instructions" &&
+            return parse(Float64, fields[1])
+    end
+    error("could not read an instruction count from perf:\n$out")
+end
+
+function instruction_report()
+    Sys.which("perf") === nothing && error("--instructions needs perf(1)")
+    println("retired instructions per unit of input, measured by perf(1)")
+    println("(a flat column is linear work, independent of the memory hierarchy)")
+    for (name, shape, scales) in SHAPES
+        @printf("\n%s\n", name)
+        @printf("  %10s %12s %18s %12s\n", "n", "input size", "instructions",
+                "instr/input")
+        sizes, counts = Float64[], Float64[]
+        for s in scales
+            n, F = shape(s)
+            N = n + sum(length, F)
+            one = perf_instructions(string(shape), s, 1)
+            six = perf_instructions(string(shape), s, 6)
+            instructions = (six - one) / 5
+            push!(sizes, N); push!(counts, instructions)
+            @printf("  %10d %12d %18.0f %12.1f\n", n, N, instructions,
+                    instructions / N)
+            flush(stdout)
+        end
+        @printf("  fitted exponent over the whole ladder: %.3f\n",
+                fitted_exponent(sizes, counts))
+        flush(stdout)
+    end
+end
+
+## entry points ##
+
+if length(ARGS) ≥ 4 && ARGS[1] == "--run"
+    run_only(ARGS[2], parse(Int, ARGS[3]), parse(Int, ARGS[4]))
+elseif length(ARGS) ≥ 1 && ARGS[1] == "--instructions"
+    instruction_report()
+else
+    verify()
+    for (name, shape, ladder) in SHAPES
+        report(name, shape, ladder)
+    end
+    crossover(star, [500, 1_000, 2_000, 4_000])
+end

--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -11,7 +11,6 @@ using LinearAlgebra: checksquare
 
 include("OverlapComponents.jl")
 using .OverlapComponents
-import .OverlapComponents: overlap_components # extended for module trees below
 
 include("StrongModuleTrees.jl")
 using .StrongModuleTrees
@@ -121,18 +120,6 @@ function tournament_factorizing_permutation(
     return map(first, P)
 end
 
-function overlap_components(
-    s :: StrongModuleTree,
-    t :: StrongModuleTree,
-    M = strong_modules(s),
-    N = strong_modules(t),
-)
-    # this is Dahlhaus' linear time algorithm; see src/OverlapComponents.jl.
-    # M ∪ N drops sets appearing in both trees: a set never overlaps a copy of
-    # itself, so keeping both would yield the same component twice.
-    return overlap_components(M ∪ N)
-end
-
 function intersect_permutation(
     V :: AbstractVector{E},   # vertices
     s :: StrongModuleTree{E}, # 1st strong module tree
@@ -140,7 +127,9 @@ function intersect_permutation(
 ) where E
     Ms = strong_modules(s)
     Mt = strong_modules(t)
-    U = filter!(overlap_components(s, t, Ms, Mt)) do X
+    # Ms ∪ Mt drops the modules the two trees share: a set never overlaps a copy
+    # of itself, so keeping both copies would yield the same component twice
+    U = filter!(overlap_components(Ms ∪ Mt)) do X
         (X in Ms || parent_node(s, X).kind != :prime) &&
         (X in Mt || parent_node(t, X).kind != :prime)
     end

--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -8,7 +8,10 @@ export StrongModuleTree, strong_modules,
 
 using LinearAlgebra
 using LinearAlgebra: checksquare
-using SparseArrays
+
+include("OverlapComponents.jl")
+using .OverlapComponents
+import .OverlapComponents: overlap_components # extended for module trees below
 
 include("StrongModuleTrees.jl")
 using .StrongModuleTrees
@@ -118,65 +121,16 @@ function tournament_factorizing_permutation(
     return map(first, P)
 end
 
-# compute whether A ∩ B, A \ B and B \ A are all non-empty
-# this assumes that A and B are both sorted
-function overlap(
-    A :: AbstractVector{T},
-    B :: AbstractVector{T},
-) where {T}
-    A === B && return false
-    A_and_B = A_not_B = B_not_A = false
-    m, n = length(A), length(B)
-    (m ≤ 0 || n ≤ 0) && return false
-    i = j = 1
-    x, y = A[i], B[j]
-    while i ≤ m && j ≤ n
-        if x == y
-            A_and_B = true # x ∈ A ∩ B
-            x = get(A, i += 1, x)
-            y = get(B, j += 1, y)
-        elseif x < y
-            A_not_B = true # x ∈ A \ B
-            x = get(A, i += 1, x)
-        else # y < x
-            B_not_A = true # y ∈ B \ A
-            y = get(B, j += 1, y)
-        end
-        A_not_B |= i ≤ m && j > n
-        B_not_A |= i > m && j ≤ n
-        A_and_B & A_not_B & B_not_A && return true
-    end
-    return false
-end
-
 function overlap_components(
     s :: StrongModuleTree,
     t :: StrongModuleTree,
     M = strong_modules(s),
     N = strong_modules(t),
 )
-    # TODO: implement linear time algorithm from this thesis:
-    ## Dalhaus 1998: "Parallel algorithms for hierarchical clustering and
-    ## applications to split decomposition and parity graph recognition"
-    ## There's also a 2000 paper by the same name, but the PDF is jumbled
-
-    O = M ∪ N
-    n = length(O)
-    R = SparseMatrixCSC{Int}(I, n, n)
-    for i = 1:n-1, j = i+1:n
-        overlap(O[i], O[j]) || continue
-        R[i,j] = R[j,i] = 1
-    end
-    while true
-        R′ = min.(1, R^2)
-        R′ == R && break
-        R .= R′
-    end
-    for (i, j) in map(Tuple, findall(!iszero, R))
-        i < j || continue
-        O[i] = O[j] = sort!(O[i] ∪ O[j])
-    end
-    return unique(O)
+    # this is Dahlhaus' linear time algorithm; see src/OverlapComponents.jl.
+    # M ∪ N drops sets appearing in both trees: a set never overlaps a copy of
+    # itself, so keeping both would yield the same component twice.
+    return overlap_components(M ∪ N)
 end
 
 function intersect_permutation(

--- a/src/OverlapComponents.jl
+++ b/src/OverlapComponents.jl
@@ -1,0 +1,425 @@
+"""
+Overlap classes of a family of sets, in linear time.
+
+Two sets `A` and `B` *overlap* if `A ∩ B`, `A \\ B` and `B \\ A` are all
+non-empty. The *overlap graph* of a family `F` has the sets of `F` as its
+vertices and joins two sets that overlap; its connected components are the
+*overlap classes* of `F`.
+
+The overlap graph can have Θ(|F|²) edges — consider `{x,y₁}, {x,y₂}, …` — so it
+cannot be built explicitly in linear time. Dahlhaus' algorithm sidesteps this by
+building a *different* graph `D` on the same vertex set which has at most
+Σ|X| edges and, although it is in general not a subgraph of the overlap graph,
+provably has the same connected components.
+
+Implemented from:
+
+  * Dahlhaus 1998/2000: "Parallel algorithms for hierarchical clustering and
+    applications to split decomposition and parity graph recognition",
+    J. Algorithms 36(2):205-240, section 4.
+  * Charbit, Habib, Limouzy, de Montgolfier, Raffinot & Rao 2007:
+    "A Note on Computing Set Overlap Classes", arXiv:0711.4573.
+
+The second paper restates Dahlhaus' section 4 much more legibly and, crucially,
+replaces its offline-lowest-common-ancestor subroutine — linear only in theory —
+with a second pass of ordered partition refinement, which is what makes the
+Θ(n + Σ|X|) bound achievable in practice. This module follows that variant.
+"""
+module OverlapComponents
+
+export overlap, overlap_classes, overlap_components
+
+## the overlap predicate ##
+
+# compute whether A ∩ B, A \ B and B \ A are all non-empty
+# this assumes that A and B are both sorted
+function overlap(
+    A :: AbstractVector{T},
+    B :: AbstractVector{T},
+) where {T}
+    A === B && return false
+    A_and_B = A_not_B = B_not_A = false
+    m, n = length(A), length(B)
+    (m ≤ 0 || n ≤ 0) && return false
+    i = j = 1
+    x, y = A[i], B[j]
+    while i ≤ m && j ≤ n
+        if x == y
+            A_and_B = true # x ∈ A ∩ B
+            x = get(A, i += 1, x)
+            y = get(B, j += 1, y)
+        elseif x < y
+            A_not_B = true # x ∈ A \ B
+            x = get(A, i += 1, x)
+        else # y < x
+            B_not_A = true # y ∈ B \ A
+            y = get(B, j += 1, y)
+        end
+        A_not_B |= i ≤ m && j > n
+        B_not_A |= i > m && j ≤ n
+        A_and_B & A_not_B & B_not_A && return true
+    end
+    return false
+end
+
+## linear-time helpers ##
+
+# stable counting sort of `items` by `key[item] ∈ 0:kmax`, descending
+function sortperm_desc(items, key::Vector{Int}, kmax::Int)
+    count = zeros(Int, kmax + 1)
+    for i in items
+        count[key[i]+1] += 1
+    end
+    next, acc = Vector{Int}(undef, kmax + 1), 1
+    for k = kmax:-1:0
+        next[k+1] = acc
+        acc += count[k+1]
+    end
+    order = Vector{Int}(undef, length(items))
+    for i in items
+        order[next[key[i]+1]] = i
+        next[key[i]+1] += 1
+    end
+    return order
+end
+
+# union-find over 1:m with path halving and union by size
+function uf_find(parent::Vector{Int}, x::Int)
+    while parent[x] != x
+        parent[x] = parent[parent[x]]
+        x = parent[x]
+    end
+    return x
+end
+
+function uf_union!(parent::Vector{Int}, size::Vector{Int}, x::Int, y::Int)
+    x, y = uf_find(parent, x), uf_find(parent, y)
+    x == y && return false
+    size[x] < size[y] && ((x, y) = (y, x))
+    parent[y] = x
+    size[x] += size[y]
+    return true
+end
+
+## ordered partition refinement ##
+
+# An ordered partition of the ground set, represented as in Charbit et al.
+# figure 4: a permutation `elems` of the ground set, its inverse `pos`, and a
+# collection of parts, each a contiguous range `lo[p]:hi[p]` of `elems`.
+struct Partition
+    elems :: Vector{Int} # ground set in partition order
+    pos   :: Vector{Int} # pos[v] = index of v in elems
+    part  :: Vector{Int} # part[v] = id of the part containing v
+    lo    :: Vector{Int} # lo[p]:hi[p] = extent of part p within elems
+    hi    :: Vector{Int}
+    count :: Vector{Int} # scratch: pivot elements seen so far in part p
+end
+
+function Partition(elems::Vector{Int})
+    n = length(elems)
+    pos = Vector{Int}(undef, n)
+    for (i, v) in enumerate(elems)
+        pos[v] = i
+    end
+    Partition(elems, pos, ones(Int, n), [1], [n], [0])
+end
+
+Partition(n::Integer) = Partition(collect(1:n))
+
+# split the last `k` elements of part `p` off as a new part, returning its id
+function split_part!(P::Partition, p::Int, k::Int)
+    push!(P.lo, P.hi[p] - k + 1)
+    push!(P.hi, P.hi[p])
+    push!(P.count, 0)
+    q = length(P.lo)
+    for j = P.lo[q]:P.hi[q]
+        P.part[P.elems[j]] = q
+    end
+    P.hi[p] = P.lo[q] - 1
+    return q
+end
+
+## step 1: lexicographically order the ground set ##
+
+# Refine the trivial partition of the ground set by each set of `F` in `order`,
+# splitting every part `C` it meets into `C \ X` followed by `C ∩ X`.
+#
+# Read `F` as a boolean matrix whose rows are the sets in `order` and whose
+# columns are ground set elements. This is then an MSD radix sort of the
+# columns: the resulting partition order is the lexicographic order of the
+# columns with the *first* row of `order` most significant — exactly the column
+# order Dahlhaus' algorithm needs (Charbit et al. lemma 7).
+function lex_order(F, order, n::Int)
+    P = Partition(n)
+    met = Int[]
+    for i in order
+        empty!(met)
+        for v in F[i]
+            p = P.part[v]
+            P.count[p] == 0 && push!(met, p)
+            P.count[p] += 1
+            # swap v down into the next free slot at the tail of its part; v is
+            # never already past that slot, since the slots beyond it hold the
+            # elements of F[i] moved so far and each is moved exactly once
+            j = P.hi[p] - P.count[p] + 1
+            k, u = P.pos[v], P.elems[j]
+            P.elems[k], P.pos[u] = u, k
+            P.elems[j], P.pos[v] = v, j
+        end
+        for p in met
+            k, P.count[p] = P.count[p], 0
+            k < P.hi[p] - P.lo[p] + 1 && split_part!(P, p, k)
+        end
+    end
+    return P
+end
+
+## step 3: compute Max ##
+
+"""
+    dahlhaus_max(F, order, sizes, elems, pos, n) -> (maxset, maxsize)
+
+For each `X ∈ F`, `Max(X)` is the largest set of `F` — in `order`, which lists
+`F` by decreasing size — that overlaps `X` and is at least as large as `X`.
+It is undefined when no set overlapping `X` is that large; `maxset[i]` is then
+`0` and `maxsize[i]` is `0`.
+
+`elems`/`pos` must be the lexicographic ground set order from [`lex_order`](@ref).
+Writing `left(X)` and `right(X)` for the first and last positions of `X` in that
+order, `Max(X)` is the set highest in `order` that contains `right(X)` but not
+`left(X)` (Charbit et al. lemma 6). So we replay the refinement of `lex_order`,
+which by construction never moves an element, and watch for the first split that
+separates `left(X)` from `right(X)`: the set that caused it is `Max(X)`.
+
+Sets are dropped once every set at least as large as them has been processed, so
+that any split found is by a set of size ≥ |X|, as `Max` requires.
+"""
+function dahlhaus_max(F, order, sizes::Vector{Int}, elems::Vector{Int},
+                      pos::Vector{Int}, n::Int)
+    m = length(F)
+    maxset, maxsize = zeros(Int, m), zeros(Int, m)
+
+    # left and right extent of each set in the lexicographic order
+    left, right = fill(n + 1, m), zeros(Int, m)
+    for i = 1:m, v in F[i]
+        left[i] = min(left[i], pos[v])
+        right[i] = max(right[i], pos[v])
+    end
+
+    # AM[j] lists the sets whose right extent is position j, in increasing order
+    # of left extent, as a doubly linked list so that any set can also be
+    # dropped in O(1) once it is too large to be anyone's Max
+    live = falses(m)
+    head, nxt, prv = zeros(Int, n), zeros(Int, m), zeros(Int, m)
+    pending = [i for i = 1:m if sizes[i] > 1] # smaller sets overlap nothing
+    for i in sortperm_desc(pending, left, n + 1) # decreasing left, pushed to
+        j = right[i]                             # the front: so AM[j] increases
+        nxt[i], prv[i], live[i] = head[j], 0, true
+        head[j] != 0 && (prv[head[j]] = i)
+        head[j] = i
+    end
+
+    function drop!(i::Int)
+        live[i] || return
+        live[i] = false
+        j = right[i]
+        prv[i] == 0 ? (head[j] = nxt[i]) : (nxt[prv[i]] = nxt[i])
+        nxt[i] != 0 && (prv[nxt[i]] = prv[i])
+    end
+
+    # `order` lists the sets by decreasing size, so each size class is one of
+    # its runs; `first_of_size` tracks where the run being processed began
+    P, met, first_of_size = Partition(elems), Int[], 1
+    for (t, i) in enumerate(order)
+        empty!(met)
+        for v in F[i]
+            p = P.part[v]
+            P.count[p] == 0 && push!(met, p)
+            P.count[p] += 1
+        end
+        for p in met
+            k, P.count[p] = P.count[p], 0
+            k < P.hi[p] - P.lo[p] + 1 || continue
+            # the elements of F[i] already occupy the tail of the part: parts
+            # are ranges of the lexicographic order, within which the members
+            # of the most significant set not yet processed come last
+            q = split_part!(P, p, k)
+            boundary = P.hi[p]
+            for j = P.lo[q]:P.hi[q]
+                while head[j] != 0 && left[head[j]] ≤ boundary
+                    x = head[j]
+                    maxset[x], maxsize[x] = i, sizes[i]
+                    drop!(x)
+                end
+            end
+        end
+        # once the last set of this size is done, nothing left can be its Max
+        if t == m || sizes[order[t+1]] != sizes[i]
+            for u = first_of_size:t
+                drop!(order[u])
+            end
+            first_of_size = t + 1
+        end
+    end
+    return maxset, maxsize
+end
+
+## the whole algorithm ##
+
+ground_set_size(F) = mapreduce(X -> isempty(X) ? 0 : Int(maximum(X)), max, F, init=0)
+
+"""
+    overlap_classes(F, n = maximum element of F) -> (class, nclasses)
+
+Assign each set of the family `F` the index of its overlap class, in
+Θ(n + Σ|X|) time. The sets of `F` must be duplicate-free subsets of `1:n`.
+
+Sets that overlap nothing form classes of their own, and equal sets are placed
+in the same class only if something else connects them: a set never overlaps
+itself or a copy of itself.
+"""
+function overlap_classes(
+    F :: AbstractVector{<:AbstractVector{<:Integer}},
+    n :: Integer = ground_set_size(F),
+)
+    m = length(F)
+    m == 0 && return Int[], 0
+    n = Int(n)
+    sizes = [length(X) for X in F]
+
+    # the algorithm silently misbehaves on out of range or repeated elements
+    # rather than failing, so rule both out up front -- still one linear pass
+    seen = falses(n)
+    for X in F
+        for v in X
+            1 ≤ v ≤ n ||
+                throw(ArgumentError("element $v is outside the ground set 1:$n"))
+            seen[v] && throw(ArgumentError("element $v is repeated within a set"))
+            seen[v] = true
+        end
+        for v in X
+            seen[v] = false
+        end
+    end
+
+    # LF order: the sets by decreasing size, ties broken arbitrarily
+    order = sortperm_desc(1:m, sizes, n)
+    P = lex_order(F, order, n)
+    _, maxsize = dahlhaus_max(F, order, sizes, P.elems, P.pos, n)
+
+    # SL[v] lists the sets containing v by increasing size, as a CSR array
+    start = zeros(Int, n + 2)
+    for i = 1:m, v in F[i]
+        start[v+1] += 1
+    end
+    start[1] = 1
+    for v = 1:n+1
+        start[v+1] += start[v]
+    end
+    cursor, SL = copy(start), Vector{Int}(undef, start[n+2] - 1)
+    for i in Iterators.reverse(order), v in F[i]
+        SL[cursor[v]] = i
+        cursor[v] += 1
+    end
+
+    # Dahlhaus' graph: walking SL[v] from the smallest set up, join consecutive
+    # sets whenever some set already passed has a Max at least as large as the
+    # later of the two. Both then overlap that set or its Max, which overlap
+    # each other, so all four share an overlap class (Charbit et al. lemma 2);
+    # and conversely every overlapping pair is joined by such a walk.
+    parent, weight = collect(1:m), ones(Int, m)
+    for v = 1:n
+        best = prev = 0
+        for t = start[v]:start[v+1]-1
+            x = SL[t]
+            prev != 0 && sizes[x] ≤ best && uf_union!(parent, weight, prev, x)
+            best = max(best, maxsize[x])
+            prev = x
+        end
+    end
+
+    class, nclasses = zeros(Int, m), 0
+    for i = 1:m
+        r = uf_find(parent, i)
+        class[r] == 0 && (class[r] = nclasses += 1)
+        class[i] = class[r]
+    end
+    return class, nclasses
+end
+
+"""
+    overlap_components(F, n = maximum element of F) -> Vector{Vector{Int}}
+
+The union of each overlap class of the family `F`, as a sorted vector, in
+Θ(n + Σ|X|) time. The sets of `F` must be duplicate-free subsets of `1:n`.
+
+Any two of the unions returned are disjoint, nested, or equal: a class whose
+union coincides with a larger set that overlaps nothing is reported separately.
+"""
+function overlap_components(
+    F :: AbstractVector{<:AbstractVector{<:Integer}},
+    n :: Integer, # the ground set is 1:n; see the one-argument methods below
+)
+    n = Int(n)
+    class, nclasses = overlap_classes(F, n)
+    nclasses == 0 && return Vector{Int}[]
+
+    # bucket the (class, element) incidences by element and then by class, so
+    # that each class ends up with its elements in increasing order
+    N = sum(length, F)
+    cs, es = Vector{Int}(undef, N), Vector{Int}(undef, N)
+    t = 0
+    for i in eachindex(F), v in F[i]
+        t += 1
+        cs[t], es[t] = class[i], v
+    end
+    for (key, kmax) in ((es, n), (cs, nclasses))
+        count = zeros(Int, kmax + 1)
+        for k in key
+            count[k+1] += 1
+        end
+        next, acc = Vector{Int}(undef, kmax + 1), 1
+        for k = 0:kmax
+            next[k+1] = acc
+            acc += count[k+1]
+        end
+        cs′, es′ = similar(cs), similar(es)
+        for t = 1:N
+            cs′[next[key[t]+1]], es′[next[key[t]+1]] = cs[t], es[t]
+            next[key[t]+1] += 1
+        end
+        copyto!(cs, cs′)
+        copyto!(es, es′)
+    end
+
+    components = [Int[] for _ = 1:nclasses]
+    for t = 1:N
+        U = components[cs[t]]
+        (isempty(U) || U[end] != es[t]) && push!(U, es[t])
+    end
+    return components
+end
+
+"""
+    overlap_components(F) -> Vector{Vector}
+
+The union of each overlap class of the family `F`, as a sorted vector. The sets
+may be over any ground set; integer elements are used as ground set indices
+directly, anything else is relabeled first, at a cost of O(Σ|X| log Σ|X|).
+"""
+function overlap_components(F::AbstractVector{<:AbstractVector{<:Integer}})
+    lo = mapreduce(X -> isempty(X) ? typemax(Int) : Int(minimum(X)), min, F, init=typemax(Int))
+    lo ≥ 1 && return overlap_components(F, ground_set_size(F))
+    shift(X, d) = [x + d for x in X]
+    U = overlap_components([shift(X, 1 - lo) for X in F], ground_set_size(F) + 1 - lo)
+    return [shift(X, lo - 1) for X in U]
+end
+
+function overlap_components(F::AbstractVector{<:AbstractVector{T}}) where {T}
+    elements = sort!(unique!(collect(T, Iterators.flatten(F))))
+    index = Dict(x => i for (i, x) in enumerate(elements))
+    U = overlap_components([[index[x] for x in X] for X in F], length(elements))
+    return [elements[X] for X in U]
+end
+
+end # module

--- a/test/overlap.jl
+++ b/test/overlap.jl
@@ -154,7 +154,6 @@ end
         s = StrongModuleTree(Gs, symgraph_factorizing_permutation(Gs))
         t = StrongModuleTree(Gd, symgraph_factorizing_permutation(Gd))
         M, N = strong_modules(s), strong_modules(t)
-        got = sort!(GraphModularDecomposition.overlap_components(s, t, M, N))
-        @test got == brute_overlap_components(M ∪ N)
+        @test sort!(overlap_components(M ∪ N)) == brute_overlap_components(M ∪ N)
     end
 end

--- a/test/overlap.jl
+++ b/test/overlap.jl
@@ -83,9 +83,14 @@ end
 
 ## randomized differential testing against the brute force reference ##
 
-rand_sets(n, m) = [sort!(shuffle(1:n)[1:rand(0:n)]) for _ = 1:m]
-rand_small_sets(n, m) = [sort!(shuffle(1:n)[1:rand(1:min(3, n))]) for _ = 1:m]
-rand_intervals(n, m) = [collect(UnitRange(minmax(rand(1:n), rand(1:n))...)) for _ = 1:m]
+# these tests draw from a private stream rather than the global one, so that
+# including this file does not shift what the randomized tests elsewhere see
+const RNG = MersenneTwister(0xf1e1d)
+
+rand_sets(n, m) = [sort!(shuffle(RNG, 1:n)[1:rand(RNG, 0:n)]) for _ = 1:m]
+rand_small_sets(n, m) = [sort!(shuffle(RNG, 1:n)[1:rand(RNG, 1:min(3, n))]) for _ = 1:m]
+rand_intervals(n, m) =
+    [collect(UnitRange(minmax(rand(RNG, 1:n), rand(RNG, 1:n))...)) for _ = 1:m]
 
 # a random hierarchy over 1:n: laminar, so no two of its sets ever overlap
 function rand_laminar(n::Int)
@@ -93,18 +98,18 @@ function rand_laminar(n::Int)
     function split(V)
         push!(F, sort(V))
         length(V) > 1 || return
-        k = rand(1:length(V)-1)
+        k = rand(RNG, 1:length(V)-1)
         split(V[1:k]); split(V[k+1:end])
     end
-    split(shuffle(1:n))
+    split(shuffle(RNG, 1:n))
     return F
 end
 
 @testset "overlap classes: random families" begin
     families = Dict(
-        "subsets"    => n -> rand_sets(n, rand(1:12)),
-        "small sets" => n -> rand_small_sets(n, rand(1:20)),
-        "intervals"  => n -> rand_intervals(n, rand(1:15)),
+        "subsets"    => n -> rand_sets(n, rand(RNG, 1:12)),
+        "small sets" => n -> rand_small_sets(n, rand(RNG, 1:20)),
+        "intervals"  => n -> rand_intervals(n, rand(RNG, 1:15)),
         "laminar"    => n -> rand_laminar(n),
         # two hierarchies over one ground set: what modular decomposition feeds
         # to overlap_components, and the only case that reaches it in this package
@@ -113,7 +118,7 @@ end
     for (name, generate) in families
         @testset "$name" begin
             for _ = 1:200
-                n = rand(1:14)
+                n = rand(RNG, 1:14)
                 F = generate(n)
                 @test fast_max(F, n) == brute_max(F, n)
                 @test same_classes(first(overlap_classes(F, n)),
@@ -143,8 +148,8 @@ end
 
 @testset "overlap components of strong module trees" begin
     for _ = 1:200
-        n = rand(3:9)
-        G = Int[i != j && rand(Bool) for i = 1:n, j = 1:n]
+        n = rand(RNG, 3:9)
+        G = Int[i != j && rand(RNG, Bool) for i = 1:n, j = 1:n]
         Gs, Gd = G .| G', G .& G'
         s = StrongModuleTree(Gs, symgraph_factorizing_permutation(Gs))
         t = StrongModuleTree(Gd, symgraph_factorizing_permutation(Gd))

--- a/test/overlap.jl
+++ b/test/overlap.jl
@@ -1,0 +1,155 @@
+using GraphModularDecomposition.OverlapComponents
+using GraphModularDecomposition.OverlapComponents: dahlhaus_max, lex_order, sortperm_desc
+
+## brute force reference: build the overlap graph and flood fill it ##
+
+function brute_overlap_classes(F::Vector{Vector{Int}})
+    m = length(F)
+    S = map(sort, F)
+    adjacent = [[j for j = 1:m if j != i && overlap(S[i], S[j])] for i = 1:m]
+    class, nclasses = zeros(Int, m), 0
+    for i = 1:m
+        class[i] == 0 || continue
+        nclasses += 1
+        stack = [i]
+        while !isempty(stack)
+            x = pop!(stack)
+            class[x] == 0 || continue
+            class[x] = nclasses
+            append!(stack, adjacent[x])
+        end
+    end
+    return class, nclasses
+end
+
+function brute_overlap_components(F::Vector{Vector{Int}})
+    class, nclasses = brute_overlap_classes(F)
+    U = [Int[] for _ = 1:nclasses]
+    for (i, X) in enumerate(F)
+        append!(U[class[i]], X)
+    end
+    return sort!(map(sort!∘unique!, U))
+end
+
+# Max(X) is the first set in LF order that overlaps X and is at least as big
+function brute_max(F::Vector{Vector{Int}}, n::Int)
+    sizes, S = map(length, F), map(sort, F)
+    order = sortperm_desc(1:length(F), sizes, n)
+    map(1:length(F)) do i
+        j = findfirst(k -> sizes[k] ≥ sizes[i] && overlap(S[i], S[k]), order)
+        j === nothing ? 0 : order[j]
+    end
+end
+
+fast_max(F::Vector{Vector{Int}}, n::Int) =
+    let sizes = map(length, F), order = sortperm_desc(1:length(F), sizes, n)
+        P = lex_order(F, order, n)
+        first(dahlhaus_max(F, order, sizes, P.elems, P.pos, n))
+    end
+
+# two set families induce the same partition of their common index set
+same_classes(a::Vector{Int}, b::Vector{Int}) =
+    Set(Set(findall(isequal(c), a)) for c in unique(a)) ==
+    Set(Set(findall(isequal(c), b)) for c in unique(b))
+
+## the worked example from Charbit et al. 2007, figures 1 and 2 ##
+
+@testset "overlap classes: paper example" begin
+    a, b, c, d, e, f, g, h, i, j, k, l = 1:12
+    F = [[a,b], [b,c,d], [c,d,e,f,g,h], [d,e], [e,f,g,h], [f,g],
+         [b,h], [j,k], [b,i,j,k,l], [k,l], [a,i]]
+    X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11 = 1:11
+
+    order = sortperm_desc(1:11, map(length, F), 12)
+    @test order == [X3, X9, X5, X2, X1, X4, X6, X7, X8, X10, X11] # figure 2 rows
+
+    # figure 2 columns: a i l j k b c d h f g e -- f and g are indistinguishable
+    P = lex_order(F, order, 12)
+    @test P.elems[1:9] == [a, i, l, j, k, b, c, d, h]
+    @test sort(P.elems[10:11]) == [f, g]
+    @test P.elems[12] == e
+
+    @test fast_max(F, 12) == brute_max(F, 12)
+    @test fast_max(F, 12)[[X1, X8, X10, X11]] == [X9, X10, X8, X9] # stated in §3
+
+    # X6 = {f,g} is nested inside X5 and X3 and meets nothing else; X8 and X10
+    # overlap each other but are nested inside X9; everything else is one class
+    class, nclasses = overlap_classes(F, 12)
+    @test nclasses == 3
+    @test same_classes(class, [1,1,1,1,1,2,1,3,1,3,1])
+    @test sort(overlap_components(F, 12)) == [collect(1:12), [f,g], [j,k,l]]
+    @test sort(overlap_components(F, 12)) == brute_overlap_components(F)
+end
+
+## randomized differential testing against the brute force reference ##
+
+rand_sets(n, m) = [sort!(shuffle(1:n)[1:rand(0:n)]) for _ = 1:m]
+rand_small_sets(n, m) = [sort!(shuffle(1:n)[1:rand(1:min(3, n))]) for _ = 1:m]
+rand_intervals(n, m) = [collect(UnitRange(minmax(rand(1:n), rand(1:n))...)) for _ = 1:m]
+
+# a random hierarchy over 1:n: laminar, so no two of its sets ever overlap
+function rand_laminar(n::Int)
+    F = Vector{Int}[]
+    function split(V)
+        push!(F, sort(V))
+        length(V) > 1 || return
+        k = rand(1:length(V)-1)
+        split(V[1:k]); split(V[k+1:end])
+    end
+    split(shuffle(1:n))
+    return F
+end
+
+@testset "overlap classes: random families" begin
+    families = Dict(
+        "subsets"    => n -> rand_sets(n, rand(1:12)),
+        "small sets" => n -> rand_small_sets(n, rand(1:20)),
+        "intervals"  => n -> rand_intervals(n, rand(1:15)),
+        "laminar"    => n -> rand_laminar(n),
+        # two hierarchies over one ground set: what modular decomposition feeds
+        # to overlap_components, and the only case that reaches it in this package
+        "two trees"  => n -> [rand_laminar(n); rand_laminar(n)],
+    )
+    for (name, generate) in families
+        @testset "$name" begin
+            for _ = 1:200
+                n = rand(1:14)
+                F = generate(n)
+                @test fast_max(F, n) == brute_max(F, n)
+                @test same_classes(first(overlap_classes(F, n)),
+                                   first(brute_overlap_classes(F)))
+                @test sort(overlap_components(F, n)) == brute_overlap_components(F)
+            end
+        end
+    end
+end
+
+@testset "overlap classes: degenerate families" begin
+    @test overlap_components(Vector{Int}[], 0) == []
+    @test overlap_components([Int[]], 0) == [[]]
+    @test overlap_components([[1], [1], [1]], 1) == [[1], [1], [1]]
+    @test overlap_components([[1,2,3], [1,2,3]], 3) == [[1,2,3], [1,2,3]]
+    # {1,2} and {2,3} overlap; {1,2,3} overlaps neither, so it is a class of
+    # its own -- two classes whose unions happen to coincide
+    @test overlap_components([[1,2], [2,3], [1,2,3]], 3) == [[1,2,3], [1,2,3]]
+    @test overlap_components([[1,2], [3,4]], 4) == [[1,2], [3,4]]
+    # elements need not be dense in 1:n, nor start at 1
+    @test overlap_components([[2,4], [4,6]]) == [[2,4,6]]
+    @test overlap_components([[-3,0], [0,5]]) == [[-3,0,5]]
+    @test overlap_components([["a","b"], ["b","c"], ["d"]]) == [["a","b","c"], ["d"]]
+end
+
+## the strong module tree entry point ##
+
+@testset "overlap components of strong module trees" begin
+    for _ = 1:200
+        n = rand(3:9)
+        G = Int[i != j && rand(Bool) for i = 1:n, j = 1:n]
+        Gs, Gd = G .| G', G .& G'
+        s = StrongModuleTree(Gs, symgraph_factorizing_permutation(Gs))
+        t = StrongModuleTree(Gd, symgraph_factorizing_permutation(Gd))
+        M, N = strong_modules(s), strong_modules(t)
+        got = sort!(GraphModularDecomposition.overlap_components(s, t, M, N))
+        @test got == brute_overlap_components(M ∪ N)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 include("setup.jl")
+include("overlap.jl")
 
 @testset "factorizing permutations" begin
     @testset "symmetric graphs" begin


### PR DESCRIPTION
Addresses the first half of #3: overlap components are now computed in linear
time. The issue stays open — see "What this does not fix" below.

## The problem

`overlap_components` tested every pair of strong modules for overlap and then
closed the resulting relation by repeatedly squaring a sparse boolean matrix
until it reached a fixpoint. Quadratic in the number of modules before the
transitive closure even starts.

Building the overlap graph explicitly is hopeless in general: a family like
`{x,y₁}, {x,y₂}, …, {x,yₘ}` has `Θ(m²)` overlapping pairs in an input of size
`2m`. Dahlhaus' insight is to build a *different* graph on the same vertex set,
with at most `Σ|X|` edges, that provably has the same connected components. It
hangs on `Max(X)`, the largest set overlapping `X`, which can be found by sorting
the ground set lexicographically by set membership and watching which set first
separates the first and last elements of `X`.

## What is here

`src/OverlapComponents.jl` — a dependency-free module implementing this in
`Θ(n + Σ|X|)`: counting sorts for the size order, ordered partition refinement
for the lexicographic ground set order, a second refinement pass with doubly
linked lists for `Max`, then Dahlhaus' graph walked with union-find, and a
two-pass radix sort to emit each class' union.

Written from the papers, not from code:

* Dahlhaus, *"Parallel algorithms for hierarchical clustering and applications
  to split decomposition and parity graph recognition"*, J. Algorithms
  36(2):205-240, section 4 — the paper the `TODO` pointed at.
* Charbit, Habib, Limouzy, de Montgolfier, Raffinot & Rao, *"A Note on
  Computing Set Overlap Classes"*, [arXiv:0711.4573](https://arxiv.org/abs/0711.4573)
  — restates Dahlhaus' section 4 far more legibly and, crucially, replaces its
  offline lowest-common-ancestor subroutine (linear only in theory) with a
  second pass of ordered partition refinement.

The only existing implementation, Rao's C code referenced by that note, is
GPL-3.0 and was deliberately not consulted.

`SparseArrays` was only used by the code this replaces, so the dependency is
dropped.

## Correctness

`test/overlap.jl`, in the standard suite:

* The worked example from Charbit et al. figures 1 and 2 — the size order, the
  lexicographic column order, and all eleven `Max` values, including the ones
  the paper states in prose (`Max(X₁) = X₉`, `Max(X₈) = X₁₀`, `Max(X₁₀) = X₈`).
* Differential testing against a brute force overlap graph over five shapes of
  random family — random subsets, small sets, intervals, laminar families, and
  two hierarchies over one ground set, which is the shape this package actually
  produces — plus degenerate families and the package's own strong module trees.

## Linearity

`bench/overlap_scaling.jl`, a script rather than a test since it works on inputs
of tens of millions.

Wall clock alone is ambiguous here: at these sizes the working set outruns every
level of cache, so measured time carries a memory hierarchy ramp that no amount
of algorithmic linearity removes, and the fitted exponents come out between 1.02
and 1.36. So the script also has an `--instructions` mode. Retired instructions
are unaffected by cache misses — a miss costs cycles, not instructions — so
instructions per unit of input is flat exactly when the work is linear:

| family shape | input size range | instructions per unit of input | fitted exponent |
| --- | --- | --- | --- |
| star, `Θ(m²)` overlapping pairs | 0.3M → 9.6M | 1323 → 1200 | 0.975 |
| sliding windows | 0.9M → 28.8M | 978 → 832 | 0.950 |
| random 8-element subsets | 0.2M → 7.2M | 1248 → 823 | 0.893 |
| nested chain, `Σ\|X\| = Θ(n²)` | 0.3M → 72M | 968 → 505 | 0.883 |
| two balanced hierarchies | 0.8M → 16.2M | 859 → 774 | 0.968 |

Against a straightforward pairwise implementation on the star family, this is
13× faster at n = 500 and 106× at n = 4000; the matrix squaring version it
actually replaces is worse still.

## What this does not fix

`#3` also mentions strong module tree construction, and that part stands. With
overlap components out of the way, the pipeline's time is now essentially all in
one place:

```
     n  factorize     trees   modules   overlap  intersect     total
   100    0.0195s   0.0003s   0.0000s   0.0000s    0.0020s   0.0359s
   200    0.1297s   0.0006s   0.0000s   0.0001s    0.0061s   0.1312s
   400    2.4699s   0.0021s   0.0001s   0.0001s    0.0254s   2.4757s
```

`symgraph_factorizing_permutation` is ~100% of the runtime and grows about 19×
per doubling of n. Its partition refinement is written over `Vector{Vector{Int}}`
with `X ∩ S`, `X in pivots` and `findfirst(isequal(X), modules)` all doing linear
scans that compare whole vectors. Beyond that, `strong_modules` materializes
every node's leaf set and so is `Θ(n · depth)`, and taking the graph as a dense
matrix is `Ω(n²)` whatever else happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
