### PR TITLE
Fix non-modular permutations from symgraph_factorizing_permutation

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -52,14 +52,20 @@ function symgraph_factorizing_permutation(
     end
 
     function add_pivot(X, Xₐ, Xₙ)
-        if X in pivots
-            push!(pivots, Xₐ)
+        i = findfirst(isequal(X), pivots)
+        if i !== nothing
+            # every vertex of X was going to be used as a pivot, so every
+            # vertex of both parts it just split into still has to be, and X
+            # itself is no longer a part: L ← L ∪ {Xₐ, Xₙ} \ {X} in the
+            # notation of Habib & Paul 2009, algorithm 2
+            deleteat!(pivots, i)
+            push!(pivots, Xₐ, Xₙ)
         else
             S, L = smaller_larger(Xₐ, Xₙ)
             push!(pivots, S)
-            i = findfirst(isequal(X), modules)
-            if i !== nothing
-                modules[i] = L
+            j = findfirst(isequal(X), modules)
+            if j !== nothing
+                modules[j] = L
             else
                 push!(modules, L)
             end

--- a/test/factorizing.jl
+++ b/test/factorizing.jl
@@ -1,0 +1,75 @@
+# Regression tests for #5: symgraph_factorizing_permutation used to return
+# permutations in which a strong module was not contiguous, which is the one
+# thing a factorizing permutation is supposed to guarantee. The cause was
+# add_pivot dropping half of a split part instead of carrying both halves
+# forward, so some vertices were never used as pivots.
+
+# graphs with a twin pair, and starting orders that used to tear the pair apart
+const TORN_APART = [
+    ([0 0 1 0 0 1 1 0 0 0
+      0 0 1 0 0 1 1 0 0 0
+      1 1 0 0 1 0 0 1 1 0
+      0 0 0 0 0 1 1 1 1 0
+      0 0 1 0 0 0 1 0 1 1
+      1 1 0 1 0 0 1 1 0 0
+      1 1 0 1 1 1 0 1 0 0
+      0 0 1 1 0 1 1 0 0 0
+      0 0 1 1 1 0 0 0 0 0
+      0 0 0 0 1 0 0 0 0 0], [2, 4, 9, 6, 7, 5, 10, 3, 8, 1], [1, 2]),
+    ([0 1 1 1 0 0 0 0 0 0
+      1 0 1 1 1 0 0 1 1 0
+      1 1 0 0 1 1 0 0 1 0
+      1 1 0 0 1 0 0 0 1 0
+      0 1 1 1 0 1 0 0 0 0
+      0 0 1 0 1 0 1 1 0 1
+      0 0 0 0 0 1 0 1 0 1
+      0 1 0 0 0 1 1 0 0 0
+      0 1 1 1 0 0 0 0 0 0
+      0 0 0 0 0 1 1 0 0 0], [9, 8, 3, 5, 7, 10, 1, 4, 6, 2], [1, 9]),
+]
+
+@testset "factorizing permutations: regressions" begin
+    for (G, order, M) in TORN_APART
+        n = size(G, 1)
+        @test G == G'
+        @test is_module(G, M)
+        p = symgraph_factorizing_permutation(G, copy(order))
+        @test sort(p) == collect(1:n)
+        @test diff(sort([findfirst(isequal(x), p) for x in M])) == [1]
+        @test is_modular_permutation(G, p)
+    end
+end
+
+# The bug only showed up on graphs carrying a module that the rest of the graph
+# does not decompose neatly around: uniformly random graphs rarely have one at
+# all, and recursively substituted graphs decompose too cleanly to trip it.
+# Planting a twin pair in an otherwise random graph does reproduce it, but only
+# for about one starting order in three thousand, so this checks a lot of them
+# at once and asserts once. Against the code before #5 was fixed this seed
+# produces 33 failures; a handful of orders would have found nothing.
+@testset "factorizing permutations: planted twins" begin
+    rng = MersenneTwister(0xf1e1d) # a private stream: see test/overlap.jl
+    failures, checked, first_failure = 0, 0, nothing
+    for _ = 1:400
+        n = rand(rng, 9:11)
+        G = zeros(Int, n, n)
+        for i = 1:n-1, j = i+1:n
+            G[i,j] = G[j,i] = rand(rng, 0:1)
+        end
+        for k = 3:n # vertices 1 and 2 are twins, so {1,2} is a module
+            G[2,k] = G[k,2] = G[1,k]
+        end
+        modules = all_strong_modules(G)
+        for _ = 1:250
+            p = symgraph_factorizing_permutation(G, shuffle(rng, 1:n))
+            checked += 1
+            is_modular_permutation(G, p, modules=modules) && continue
+            failures += 1
+            first_failure === nothing && (first_failure = (copy(G), copy(p)))
+        end
+    end
+    @test checked == 100_000
+    failures == 0 ||
+        @warn "non-modular permutation" G=first_failure[1] p=first_failure[2]
+    @test failures == 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 include("setup.jl")
 include("overlap.jl")
+include("factorizing.jl")
 
 @testset "factorizing permutations" begin
     @testset "symmetric graphs" begin


### PR DESCRIPTION
Fixes #5.

## The bug

`symgraph_factorizing_permutation` could return a permutation in which a strong
module was not contiguous — the one property a factorizing permutation is
supposed to have. On the graph in #5 the twin pair `{1, 2}` came back at
positions 4 and 6 with vertex 8 wedged between them.

## The cause

The refinement keeps two lists of parts: `L` (`pivots` in the code), whose parts
will have *every* vertex used as a pivot, and `K` (`modules`), whose parts
contribute only one. When a part `Y ∈ L` is split by a pivot, Habib & Paul's
algorithm 2 says

> `L ← L ∪ {Ymin, Ymax} \ {Y}`

Both halves inherit `Y`'s place in `L`, and `Y` itself goes away, since it is no
longer a part. `add_pivot` did neither:

```julia
if X in pivots
    push!(pivots, Xₐ)     # only Xₐ = X ∩ N(x), and X stays in the list
```

So the vertices of `X \ N(x)` were never used as pivots and the splits that
depended on them never happened. Leaving the stale `X` in the list is a second
error: it gets popped later as a pivot set, and `S = N_adj(x) \ E` in
`partition_refinement!` then subtracts a superset of the part `x` really belongs
to, suppressing further splits.

Both halves of the rule matter, and they are not independent — fixing only the
removal, without adding `Xₙ`, makes things considerably worse:

| `add_pivot` behaviour | non-modular permutations per 100k |
| --- | --- |
| as committed before this PR | 39 |
| remove `X`, still only add `Xₐ` | 626 |
| add both halves, keep `X` | 0 |
| **add both halves, remove `X` (algorithm 2)** | **0** |

The last two are indistinguishable on the failure count, so this takes the
faithful one.

I also checked the other place the implementation departs from the paper — the
`between` test in `refine!`, which orders the two halves of a split part. That
one is right as it stands: rewriting it to key on the center lying between the
pivot and the part, which is how algorithm 4 states the rule, makes the failure
rate far worse (1400–4400 per 100k), so the existing formulation is the correct
reading.

## Verification

* 5,670,000 random starting orders, over uniformly random graphs, graphs with a
  planted twin pair, and graphs with several planted modules, at n = 8 … 14 —
  no non-modular permutation. The same sweep fails throughout before the fix.
* Exhaustively, every graph on n ≤ 6 vertices against every starting order —
  23,594,424 permutations, all modular. (n ≤ 6 cannot exhibit the bug either
  way; this is a regression check.)
* Both graphs from #5 now return the module adjacent.

## Tests

`test/factorizing.jl` adds both graphs from #5 as explicit regressions, and a
seeded sweep over planted-twin graphs.

That sweep is deliberately large. A twin pair gets torn apart for only about one
starting order in three thousand, so a handful of random graphs finds nothing at
all — my first attempt checked 1000 orders and passed happily against the broken
code. It now checks 100,000 orders and asserts once, which takes about 3 seconds
and reports 33 failures against the code before this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
