### PR TITLE
Remove the avoidable quadratic work in tree construction and partition refinement

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -30,9 +30,18 @@ function symgraph_factorizing_permutation(
     N_adj(x, X=V) = [y for y in X if y != x && G[x,y] != 0]
     N_non(x, X=V) = [y for y in X if y != x && G[x,y] == 0]
 
+    # membership flags, so that refine! can split each part in one pass over it
+    # instead of intersecting it with the pivot set, and so that the pivot set
+    # can be subtracted from a neighbourhood as the neighbourhood is built
+    in_pivot_set = falses(checksquare(G))
+    in_pivot_part = falses(checksquare(G))
+
     smaller_larger(A, B) = length(A) <= length(B) ? (A, B) : (B, A)
 
     function refine!(P, S, x)
+        for y in S
+            in_pivot_set[y] = true
+        end
         i, between = 0, false
         while (i += 1) <= length(P)
             X = P[i]
@@ -40,14 +49,25 @@ function symgraph_factorizing_permutation(
                 between = !between
                 continue
             end
-            Xₐ = X ∩ S
-            isempty(Xₐ) && continue
-            Xₙ = X \ Xₐ
-            isempty(Xₙ) && continue
+            # X ∩ S followed by X \ (X ∩ S) walks S once per part, so refining
+            # the whole partition costs O(|P|·|S|); splitting X against the
+            # membership flags instead costs O(|X|), and O(Σ|X|) over the
+            # partition. element order within each half is the order within X,
+            # exactly as intersect and setdiff give it
+            k = count(y -> in_pivot_set[y], X)
+            (k == 0 || k == length(X)) && continue
+            Xₐ, Xₙ = Vector{Int}(undef, k), Vector{Int}(undef, length(X) - k)
+            a = b = 0
+            for y in X
+                in_pivot_set[y] ? (Xₐ[a += 1] = y) : (Xₙ[b += 1] = y)
+            end
             P[i] = Xₙ
             insert!(P, i + between, Xₐ)
             add_pivot(X, Xₐ, Xₙ)
             i += 1
+        end
+        for y in S
+            in_pivot_set[y] = false
         end
     end
 
@@ -76,9 +96,18 @@ function symgraph_factorizing_permutation(
         while init_partition!(P)
             while !isempty(pivots)
                 E = pop!(pivots)
+                for y in E
+                    in_pivot_part[y] = true
+                end
                 for x in E
-                    S = N_adj(x) \ E
+                    # N_adj(x) \ E, without materializing the neighbourhood
+                    # first and then hashing E to subtract it
+                    S = [y for y in V
+                         if y != x && G[x,y] != 0 && !in_pivot_part[y]]
                     refine!(P, S, x)
+                end
+                for y in E
+                    in_pivot_part[y] = false
                 end
             end
         end

--- a/src/StrongModuleTrees.jl
+++ b/src/StrongModuleTrees.jl
@@ -50,14 +50,31 @@ function StrongModuleTree(
     end
 
     # remove non-module "dummy" nodes
-    let s = Int[]
+    #
+    # a node spanning i:j is a module iff no cutter of a pair inside it lies
+    # outside it. rescanning lc and uc across the whole span to find that out
+    # costs O(span) per node; instead every open paren carries the extremes of
+    # everything seen since it opened, and passes them to its parent on the way
+    # out, which is O(1) per node
+    let s = Int[], lo = Int[], hi = Int[]
         for j = 1:n
-            for _ = 1:op[j]; push!(s, j); end
+            # the cutters of the pair (j-1, j) belong to every node still open
+            if j > 1 && !isempty(s)
+                lo[end] = min(lo[end], lc[j-1])
+                hi[end] = max(hi[end], uc[j-1])
+            end
+            for _ = 1:op[j]
+                push!(s, j)
+                push!(lo, typemax(Int))
+                push!(hi, typemin(Int))
+            end
             for _ = 1:cl[j]
-                i = pop!(s)
+                i, l, u = pop!(s), pop!(lo), pop!(hi)
+                if !isempty(s)
+                    lo[end] = min(lo[end], l)
+                    hi[end] = max(hi[end], u)
+                end
                 if i < j
-                    l = minimum(lc[k] for k = i:j-1)
-                    u = maximum(uc[k] for k = i:j-1)
                     i <= l && u <= j && continue
                 end
                 op[i] -= 1
@@ -129,15 +146,25 @@ function StrongModuleTree(
 ) where {T <: Any}
     # continues from end of StrongModuleTree(G, p)
 
+    # returns the classified node together with its first leaf. the leaf comes
+    # back up rather than being searched for again because first_leaf walks to
+    # the bottom of the subtree: calling it inside the comparison loop below
+    # costs O(depth) every time, which is quadratic on a deep tree
     function classify_nodes(t::Vector)
         n = length(t)
+        nodes = Vector{Union{T,StrongModuleTree{T}}}(undef, n)
+        leaf = Vector{T}(undef, n)
+        for i = 1:n
+            x = t[i]
+            nodes[i], leaf[i] = x isa Vector ? classify_nodes(x) : (x, x)
+        end
         counts = zeros(Int, n)
-        x, y = first_leaf(t[1]), first_leaf(t[2])
+        x, y = leaf[1], leaf[2]
         edge = (G[y,x], G[x,y])
         local a, b
         for i = 1:n, j = 1:n
             i == j && continue
-            x, y = first_leaf(t[i]), first_leaf(t[j])
+            x, y = leaf[i], leaf[j]
             a, b = G[y,x], G[x,y]
             if edge == (a, b)
                 counts[i] += 1
@@ -152,7 +179,7 @@ function StrongModuleTree(
             all(d -> d == 2, diff(counts)) ? :linear : :prime
         edge[1] <= edge[2] || (edge = reverse(edge))
         kind == :prime && (edge = ())
-        StrongModuleTree{T}(kind, edge, map(x->x isa Vector ? classify_nodes(x) : x, t))
+        return StrongModuleTree{T}(kind, edge, nodes), leaf[1]
     end
 
     function delete_weak_modules!(t::StrongModuleTree)
@@ -179,7 +206,7 @@ function StrongModuleTree(
             pop!(s)
         end
     end
-    t = classify_nodes(s[end])
+    t, _ = classify_nodes(s[end])
     delete_weak_modules!(t)
     return t
 end


### PR DESCRIPTION
Addresses the second half of #3 — "parts of strong module tree construction
from a factorizing permutation that may be super-linear unnecessarily" — and,
along the way, the step that turned out to dominate everything else.

Nothing here changes what the package computes. Every factorizing permutation
and every tree is identical to `master` across 4000 random symmetric graphs,
twin-planted graphs and digraphs, with identical node types, kinds, edges,
leaves and strong module sets.

## Building the tree

Two steps did work proportional to the size of a subtree for each node of it.

`classify_nodes` called `first_leaf` on both operands of every pairwise
comparison it makes, and `first_leaf` walks to the bottom of a subtree, so a
node with `k` children cost `O(k² · depth)` instead of `O(k²)`. It now
classifies the children first and takes each one's first leaf from the
recursive call, which already knows it. That also drops a dynamic dispatch per
comparison, since the leaves now live in a `Vector{T}` rather than being pulled
out of a `Vector{Union{...}}`.

The pass that drops non-module nodes asked, for each node, for the smallest
lower cutter and largest upper cutter over the node's whole span, and answered
by rescanning `lc` and `uc`. The nodes are properly nested, so each open paren
can instead accumulate the extremes of everything seen since it opened and fold
them into its parent as it closes — `O(1)` per node.

On the phase that changed, at n = 4000:

| graph | before | after | |
| --- | --- | --- | --- |
| modules nested all the way down | 0.1699s | 0.0023s | 74× |
| one complete node, 4000 children | 1.6342s | 0.0728s | 22× |

## The step that actually dominated

With that done, profiling the whole decomposition put essentially all of the
time in `symgraph_factorizing_permutation`, at roughly `n^2.9`. The hot line was

```julia
Xₐ = X ∩ S
...
Xₙ = X \ Xₐ
```

in `refine!`. Both of those walk `S` as well as `X`, and they run for every part
of the partition, so refining by one pivot costs `O(|P|·|S|)` — where the whole
point of the operation is that it should cost `O(|S|)` (Habib & Paul 2009,
lemma 10). Marking the pivot set in a flag array once per call and splitting
each part against the flags in one pass makes it `O(Σ|X|)`; the neighbourhood
minus the pivot part is likewise built in a single scan instead of being
materialized and then hashed against.

| n | before | after | |
| --- | --- | --- | --- |
| 100 | 0.0084s | 0.0003s | |
| 200 | 0.0682s | 0.0013s | |
| 400 | 0.4564s | 0.0054s | |
| 800 | 3.4150s | 0.0210s | **163×** |
| | ~n^2.9 | ~n^2.05 | |

End to end, decomposing a random graph at n = 800 goes from 3.4628s to 0.0217s,
160×, with the measured exponent down from 2.74 to 1.96.

## What is still not linear

The package is faster and better behaved, but it is not linear time, and the
rest is not a local change:

* **The dense matrix.** Each pivot scans a row for its neighbourhood, finding a
  pair's cutters scans a row, and classifying a complete or linear node compares
  every pair of children. All three are quadratic because the graph arrives as
  an `AbstractMatrix`. The linear-time algorithms assume adjacency lists, so
  getting past this is an API change.
* **`intersect_permutation`,** on the digraph path, is now the bottleneck there:
  0.2251s of the 0.2804s a digraph at n = 800 takes, against 0.0004s for
  overlap components. It looks modules up with `X in Ms` — a linear scan
  comparing whole vectors — calls `parent_node`, which recomputes `leaves` as it
  descends, and builds the nesting with `child in parent` and `filter!` over
  vectors. None of that needs to be superlinear.

So #3 should stay open after this; both things it names are now done, but its
headline claim is not yet true.

## Verification

* Output identical to `master` on 4000 random graphs and digraphs, checked as
  printed trees and again as node types, kinds, edges, leaves and strong module
  sets.
* The correctness sweep from #5 still passes on this branch: 5,670,000 random
  starting orders across three graph families at n = 8 … 14, plus every graph on
  n ≤ 6 against every starting order — 23,594,424 permutations — all modular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
