### PR TITLE
Answer "which node is above this set" from an index

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -16,6 +16,7 @@ using .OverlapComponents
 
 include("StrongModuleTrees.jl")
 using .StrongModuleTrees
+using .StrongModuleTrees: TreeIndex, containing_node, parent_index
 
 const \ = setdiff
 
@@ -346,40 +347,64 @@ function intersect_permutation(
 ) where E
     Ms = strong_modules(s)
     Mt = strong_modules(t)
+    # Index both trees once. Everything below asks, of a great many sets, which
+    # node sits above the set and whether the set is exactly one of the tree's
+    # modules; unindexed, the first walks the tree materializing the leaf set of
+    # every child it passes and the second scans the whole list of modules.
+    si, ti = TreeIndex(s), TreeIndex(t)
     # Ms ∪ Mt drops the modules the two trees share: a set never overlaps a copy
     # of itself, so keeping both copies would yield the same component twice
     U = filter!(overlap_components(Ms ∪ Mt)) do X
-        (X in Ms || parent_node(s, X).kind != :prime) &&
-        (X in Mt || parent_node(t, X).kind != :prime)
+        # `X in Ms` is `containing_node` reporting an exact match, and when it
+        # reports none the node it found is what parent_node would have returned
+        i, exact = containing_node(si, X)
+        (exact || si.node[i].kind != :prime) || return false
+        j, exact = containing_node(ti, X)
+        return exact || ti.node[j].kind != :prime
     end
     for x in V; push!(U, [x]); end
-    R = Dict()
+    # keyed by node numbers rather than by the nodes themselves, which hash
+    # their whole subtree
+    R = Dict{Tuple{Int,Int},Set{Int}}()
     for X in U
-        S = parent_node(t, X)
-        T = parent_node(s, X)
-        union!(get!(()->Set{Int}(), R, (S, T)), X)
+        key = (parent_index(ti, X), parent_index(si, X))
+        union!(get!(()->Set{Int}(), R, key), X)
     end
     N = U ∪ map(sort!∘collect, values(R))
     N = filter!(X->length(X) > 1, N)
-    T = Any[[] for x in V]
-    for node in sort!(N, by=length, rev=true)
-        an = Vector{Any}(node)
-        for x in node
-            push!(T[x], an)
+    # N is laminar, so it is the node set of a tree, and sorting by decreasing
+    # size makes the sets holding a given leaf that leaf's ancestors, outermost
+    # first. That gives every set its depth in one pass over the sets. Nesting
+    # them by searching and filtering instead costs O(|parent|·|child|) for each
+    # parent and child, and pays it once per leaf of the child.
+    sort!(N, by=length, rev=true)
+    chain = [Int[] for _ in V] # leaf -> its ancestors in N, outermost first
+    for (i, X) in enumerate(N), x in X
+        push!(chain[x], i)
+    end
+    depth = zeros(Int, length(N))
+    for c in chain, (k, i) in enumerate(c)
+        depth[i] = k
+    end
+    # Walk the tree, taking each node's own leaves before any of its children.
+    # Grouping them is not cosmetic: a module can fail to be a node of N and
+    # still have to come out contiguous, and the only thing keeping such a
+    # module together is that the leaves belonging to a node directly are not
+    # separated by that node's children.
+    p, entered = E[], falses(length(N))
+    function emit(i)
+        for x in N[i]
+            length(chain[x]) == depth[i] && push!(p, x) # i holds x directly
+        end
+        for x in N[i]
+            length(chain[x]) == depth[i] && continue
+            c = chain[x][depth[i]+1]
+            entered[c] && continue
+            entered[c] = true
+            emit(c)
         end
     end
-    for x in V, i = 1:length(T[x])-1
-        parent = T[x][i]
-        child = T[x][i+1]
-        child in parent && continue
-        filter!(y->!(y in child), parent)
-        push!(parent, child)
-    end
-    T = T[1][1]
-    p = E[]
-    record_vals(v::Vector) = foreach(record_vals, v)
-    record_vals(x::E) = push!(p, x)
-    record_vals(T)
+    emit(first(chain[first(V)]))
     return p
 end
 

--- a/src/StrongModuleTrees.jl
+++ b/src/StrongModuleTrees.jl
@@ -283,6 +283,83 @@ nodes(t::StrongModuleTree) = nodes!(typeof(t)[], t)
 
 strong_modules(t::StrongModuleTree) = map(sort!∘leaves, nodes(t))
 
+"""
+    TreeIndex(t)
+
+An index over the nodes of `t`: where each leaf falls in the tree's leaf order,
+which range of that order each node spans, and each node's parent.
+
+`parent_node` answers "which node sits just above this set of leaves" by
+materializing the leaf set of every child it passes, which costs a subtree walk
+per step. The same question is a lowest-common-ancestor query: the node wanted
+is the lowest one whose leaf range covers the set, and a set's range is fixed by
+its lowest and highest leaf alone. Building the index costs one pass over the
+tree, after which a query is O(|S| + depth) and touches no leaf sets at all.
+"""
+struct TreeIndex{T}
+    leaf   :: Dict{T,Int}                   # leaf -> its place in the leaf order
+    node   :: Vector{StrongModuleTree{T}}
+    parent :: Vector{Int}                   # node -> its parent, 0 for the root
+    first  :: Vector{Int}                   # node -> its first leaf's place
+    last   :: Vector{Int}                   # node -> its last leaf's place
+    holder :: Vector{Int}                   # leaf place -> the node just above it
+end
+
+function TreeIndex(t::StrongModuleTree{T}) where {T}
+    ix = TreeIndex{T}(Dict{T,Int}(), StrongModuleTree{T}[], Int[], Int[], Int[], Int[])
+    function visit(x::StrongModuleTree{T}, parent::Int)
+        push!(ix.node, x); push!(ix.parent, parent)
+        push!(ix.first, length(ix.leaf) + 1); push!(ix.last, 0)
+        i = length(ix.node)
+        for y in x.nodes
+            if y isa StrongModuleTree
+                visit(y, i)
+            else
+                ix.leaf[y] = length(ix.leaf) + 1
+                push!(ix.holder, i)
+            end
+        end
+        ix.last[i] = length(ix.leaf)
+        return i
+    end
+    visit(t, 0)
+    return ix
+end
+
+"""
+    containing_node(ix, S) -> (node, exact)
+
+The lowest node of the indexed tree whose leaves contain every element of `S`,
+and whether its leaves are exactly `S` — which is what asking whether `S` is one
+of the tree's strong modules amounts to.
+"""
+function containing_node(ix::TreeIndex, S)
+    lo = hi = 0
+    for x in S
+        p = ix.leaf[x]
+        lo == 0 && (lo = hi = p)
+        p < lo && (lo = p)
+        p > hi && (hi = p)
+    end
+    lo == 0 && return (1, false) # nothing to contain: the root, and not exactly
+    i = ix.holder[lo]
+    while (ix.first[i] > lo || ix.last[i] < hi) && ix.parent[i] != 0
+        i = ix.parent[i]
+    end
+    return (i, ix.last[i] - ix.first[i] + 1 == length(S))
+end
+
+"""
+    parent_index(ix, S)
+
+The node [`parent_node`](@ref) would return: the lowest node whose leaves
+*strictly* contain `S`, so a node whose leaves are exactly `S` yields its parent.
+"""
+function parent_index(ix::TreeIndex, S)
+    i, exact = containing_node(ix, S)
+    exact && ix.parent[i] != 0 ? ix.parent[i] : i
+end
+
 function parent_node(t::StrongModuleTree, S::Vector)
     for x in t.nodes
         x isa StrongModuleTree || continue

--- a/test/factorizing.jl
+++ b/test/factorizing.jl
@@ -73,3 +73,38 @@ end
         @warn "non-modular permutation" G=first_failure[1] p=first_failure[2]
     @test failures == 0
 end
+
+# Regression for the digraph path. intersect_permutation builds a laminar family
+# of sets and walks it to lay the vertices out. A strong module can fail to be
+# one of those sets and still have to come out contiguous: below, {1,4} is a
+# module, is not one of the sets, and stays together only because the leaves
+# belonging to a node directly are not separated by that node's children.
+@testset "factorizing permutations: digraph regressions" begin
+    G = [0 0 1 0 0
+         0 0 0 0 0
+         0 1 0 0 0
+         0 0 1 0 0
+         0 1 1 0 0]
+    @test is_module(G, [1, 4])
+    p = digraph_factorizing_permutation(G)
+    @test sort(p) == collect(1:5)
+    @test diff(sort([findfirst(isequal(x), p) for x in (1, 4)])) == [1]
+    @test is_modular_permutation(G, p)
+
+    # That graph turned up about once in 50,000 random digraphs, so a sweep of a
+    # few thousand would have proved nothing -- and did not, when it was tried.
+    # This one reports two failures against the code the regression is for.
+    rng = MersenneTwister(3) # a private stream: see test/overlap.jl
+    failures, first_failure = 0, nothing
+    for _ = 1:25_000
+        n = rand(rng, 4:7)
+        H = Int[i != j && rand(rng, Bool) for i = 1:n, j = 1:n]
+        q = digraph_factorizing_permutation(H)
+        sort(q) == collect(1:n) && is_modular_permutation(H, q) && continue
+        failures += 1
+        first_failure === nothing && (first_failure = (copy(H), copy(q)))
+    end
+    failures == 0 ||
+        @warn "non-modular permutation" G=first_failure[1] p=first_failure[2]
+    @test failures == 0
+end


### PR DESCRIPTION
Step 3 of the plan in #3: `intersect_permutation`, which #9 left as the digraph
path's bottleneck.

## The problem

`intersect_permutation` asks two questions of a strong module tree, once for
each set in a family the size of the vertex set:

* **which node sits just above this set** — `parent_node`, which walks down the
  tree materializing the leaf set of every child it passes;
* **is this set exactly one of the tree's modules** — `X in Ms`, a linear scan
  over the whole list of modules comparing vectors.

Both are linear in the tree per question, so the pair costs Θ(n) per set and
Θ(n²) over the family.

## Both are the same LCA question

The node wanted is the lowest one whose leaves cover the set; a set's cover is
fixed by its lowest and highest leaf alone; and the set is a module exactly when
that node's leaves are no more numerous than the set. So `TreeIndex` records,
in one pass over the tree, where each leaf falls in the leaf order, which range
of that order each node spans, and each node's parent. A query is then
O(|S| + depth) and touches no leaf set at all.

The result dictionary is keyed by node numbers rather than by the nodes
themselves, which hash their entire subtree.

## And the tail that builds the tree

That part searched each parent for each child and filtered the child's leaves
out of it — O(|parent|·|child|) per pair, paid once per leaf of the child. The
sets are laminar, so sorting them by decreasing size makes the sets holding a
given leaf that leaf's ancestors, outermost first, which gives every set its
depth in one pass. Walking the tree from there is O(Σ|node|).

## Effect

`intersect_permutation` on digraphs built by substitution:

| n | before | after | |
| ---: | ---: | ---: | ---: |
| 200 | 0.0142s | 0.0007s | |
| 400 | 0.0628s | 0.0014s | |
| 800 | 0.2464s | 0.0027s | |
| 1600 | 0.9518s | **0.0057s** | 167× |
| 3200 | — | 0.0132s | |
| | ~n^1.9 | ~n^1.0 | |

End to end the digraph path goes 7.2510s → 2.6981s at n = 3200. Where its time
goes now:

| n = 3200 | |
| --- | ---: |
| `G\|G'`, `G&G'` | 0.1220s |
| two `symgraph_factorizing_permutation` | **1.4797s** |
| two `StrongModuleTree` | 0.4629s |
| `intersect_permutation` | 0.0131s |
| `StrongModuleTree(H, p)` | 0.2335s |
| `sort_leaves!` | 0.4015s |

`intersect_permutation` is 0.5% of it, rather than most of it. What dominates
now is the two factorizations, quadratic because `G .| G'` and `G .& G'` are
dense matrices — which is the same "linear in the input you were handed" story
as the symmetric path, since a dense matrix is n² words.

## Verification

* Trees identical to `master` over 3000 random graphs and digraphs.
* `TreeIndex` agrees with `parent_node`, and its exactness flag agrees with
  `X in Ms`, on all 49,612 (tree, subset) pairs — every subset of every graph in
  a random sample.
* 6000 digraph permutations checked against brute-force strong modules, over
  uniformly random and substituted digraphs, dense and sparse.
* Every digraph on n ≤ 4 vertices — 4,164 of them — exhaustively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
