### PR TITLE
Find cutters by merging relation lists on sparse input

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -14,10 +14,6 @@ using SparseArrays: nonzeros, nzrange, rowvals
 include("OverlapComponents.jl")
 using .OverlapComponents
 
-include("StrongModuleTrees.jl")
-using .StrongModuleTrees
-using .StrongModuleTrees: TreeIndex, containing_node, parent_index
-
 const \ = setdiff
 
 ## iterating a vertex's neighbours ##
@@ -44,6 +40,11 @@ function neighbors(G::SparseMatrixCSC, x::Integer)
     rows, vals = rowvals(G), nonzeros(G)
     (rows[k] for k in nzrange(G, x) if rows[k] != x && !iszero(vals[k]))
 end
+
+include("StrongModuleTrees.jl")
+using .StrongModuleTrees
+using .StrongModuleTrees: TreeIndex, containing_node, parent_index
+
 
 function symgraph_factorizing_permutation(
     G :: AbstractMatrix,

--- a/src/StrongModuleTrees.jl
+++ b/src/StrongModuleTrees.jl
@@ -5,6 +5,8 @@ export StrongModuleTree, strong_modules,
     nodes, node_count, parent_node, is_cograph
 
 using ..GraphModularDecomposition
+using ..GraphModularDecomposition: neighbors
+using SparseArrays: SparseMatrixCSC
 
 ## core type definition ##
 
@@ -14,21 +16,122 @@ struct StrongModuleTree{T} <: AbstractVector{T}
     nodes::Vector{Union{T,StrongModuleTree{T}}}
 end
 
-## constructing StrongModuleTrees ##
+## finding cutters ##
 
-function StrongModuleTree(
-    G::AbstractMatrix, # the graph/digraph/2-structure as a matrix
-    p::Vector{Int} = graph_factorizing_permutation(G),
-)
-    # initialize data structures
+# A vertex w cuts the pair (u, v) when it is related differently to the two of
+# them — when (G[w,u], G[u,w]) and (G[w,v], G[v,w]) differ.
+#
+# There are two ways to find the first and last such w, and which one is right
+# depends on the representation, so there is a method per representation below.
+#
+# Scanning the permutation looks at every place before the cutter whether or not
+# anything is there, so it is Θ(n) for a pair with no cutter and Θ(n²) over the
+# whole permutation — but on a graph with edges everywhere it usually stops at
+# the first place it looks, and it reads the matrix directly.
+#
+# Merging looks only at the places holding a relation, which is Θ(deg u + deg v)
+# per pair and Θ(n + m) over the permutation — but it has to list every vertex's
+# relations first, and that build costs the size of the representation. On a
+# dense matrix the build alone is Θ(n²), against a scan that is usually Θ(1) per
+# pair, so paying it there is a bad trade by three orders of magnitude.
+#
+# Both are linear in the representation they are chosen for.
+
+transposed(G::SparseMatrixCSC) = copy(G')
+
+# For each place in the permutation, the places related to it, in increasing
+# order, with the labels in each direction. Stored as one flat array per field
+# with a start index per place.
+struct Relations
+    start :: Vector{Int}
+    place :: Vector{Int}
+    in    :: Vector{Int}
+    out   :: Vector{Int}
+end
+
+Base.getindex(r::Relations, j::Integer) = r.start[j]:r.start[j+1]-1
+
+function Relations(G::SparseMatrixCSC, p::Vector{Int}, pos::Vector{Int})
     n = length(p)
-    op = zeros(Int,n); op[1] = 1
-    cl = zeros(Int,n); cl[n] = 1
-    lc = collect(1:n-1)
-    uc = collect(2:n)
+    Gt = transposed(G)
+    # collect each place's related places, deduplicating the two directions
+    seen = falses(n)
+    lists = Vector{Vector{Int}}(undef, n)
+    for j = 1:n
+        u, places = p[j], Int[]
+        for w in Iterators.flatten((neighbors(G, u), neighbors(Gt, u)))
+            k = pos[w]
+            seen[k] && continue
+            seen[k] = true
+            push!(places, k)
+        end
+        for k in places
+            seen[k] = false
+        end
+        lists[j] = places
+    end
+    total = sum(length, lists)
+    start = zeros(Int, n + 2)
+    start[1] = 1
+    for j = 1:n
+        start[j+1] = start[j] + length(lists[j])
+    end
+    start[n+2] = start[n+1]
+    place, inlab, outlab = Vector{Int}(undef, total), Vector{Int}(undef, total),
+                           Vector{Int}(undef, total)
+    for j = 1:n
+        u, at = p[j], start[j]
+        sort!(lists[j])
+        for k in lists[j]
+            w = p[k]
+            place[at], inlab[at], outlab[at] = k, G[w,u], G[u,w]
+            at += 1
+        end
+    end
+    return Relations(start, place, inlab, outlab)
+end
 
-    # count open and close parens in fracture tree
-    # find lower and upper cutters for node pairs
+# The first place before `j` that cuts the pair at places j and j+1, or 0.
+function lower_cutter(r::Relations, j::Int)
+    a, b = r[j], r[j+1]
+    ia, ib = first(a), first(b)
+    while true
+        pa = ia <= last(a) ? r.place[ia] : typemax(Int)
+        pb = ib <= last(b) ? r.place[ib] : typemax(Int)
+        k = min(pa, pb)
+        k < j || return 0
+        if pa == k && pb == k
+            (r.in[ia] != r.in[ib] || r.out[ia] != r.out[ib]) && return k
+            ia += 1; ib += 1
+        elseif pa == k
+            return k # related to one and not the other
+        else
+            return k
+        end
+    end
+end
+
+# The last place after `j+1` that cuts the pair at places j and j+1, or 0.
+function upper_cutter(r::Relations, j::Int)
+    a, b = r[j], r[j+1]
+    ia, ib = last(a), last(b)
+    while true
+        pa = ia >= first(a) ? r.place[ia] : 0
+        pb = ib >= first(b) ? r.place[ib] : 0
+        k = max(pa, pb)
+        k > j + 1 || return 0
+        if pa == k && pb == k
+            (r.in[ia] != r.in[ib] || r.out[ia] != r.out[ib]) && return k
+            ia -= 1; ib -= 1
+        else
+            return k
+        end
+    end
+end
+
+# scanning: for a matrix that stores every pair, so that reading one is O(1)
+function find_cutters!(op, cl, lc, uc, G::AbstractMatrix, p::Vector{Int})
+    n = length(p)
     for j = 1:n-1
         for i = 1:j-1
             G[p[i],p[j]] == G[p[i],p[j+1]] &&
@@ -48,6 +151,48 @@ function StrongModuleTree(
             break
         end
     end
+end
+
+# merging: for a matrix that stores only the relations there are
+function find_cutters!(op, cl, lc, uc, G::SparseMatrixCSC, p::Vector{Int})
+    n = length(p)
+    pos = zeros(Int, n)
+    for (k, v) in enumerate(p)
+        pos[v] = k
+    end
+    relations = Relations(G, p, pos)
+    for j = 1:n-1
+        i = lower_cutter(relations, j)
+        if i != 0
+            op[i] += 1
+            cl[j] += 1
+            lc[j] = i
+        end
+        i = upper_cutter(relations, j)
+        if i != 0
+            op[j+1] += 1
+            cl[i] += 1
+            uc[j] = i
+        end
+    end
+end
+
+## constructing StrongModuleTrees ##
+
+function StrongModuleTree(
+    G::AbstractMatrix, # the graph/digraph/2-structure as a matrix
+    p::Vector{Int} = graph_factorizing_permutation(G),
+)
+    # initialize data structures
+    n = length(p)
+    op = zeros(Int,n); op[1] = 1
+    cl = zeros(Int,n); cl[n] = 1
+    lc = collect(1:n-1)
+    uc = collect(2:n)
+
+    # count open and close parens in fracture tree
+    # find lower and upper cutters for node pairs
+    find_cutters!(op, cl, lc, uc, G, p)
 
     # remove non-module "dummy" nodes
     #

--- a/test/factorizing.jl
+++ b/test/factorizing.jl
@@ -136,3 +136,31 @@ end
     end
     @test disagreements == 0
 end
+
+# Cutters are found two different ways, by scanning a dense matrix and by
+# merging the relation lists of a sparse one, so the representation is now
+# something the answer could depend on and must not.
+@testset "cutters agree across representations" begin
+    rng = MersenneTwister(0x5ca7) # a private stream: see test/overlap.jl
+    for _ = 1:2000
+        n = rand(rng, 2:14)
+        G = zeros(Int, n, n)
+        kind = rand(rng, 1:3)
+        if kind == 1                                        # symmetric graph
+            for i = 1:n-1, j = i+1:n
+                G[i,j] = G[j,i] = rand(rng, 0:1)
+            end
+        elseif kind == 2                                    # digraph
+            for i = 1:n, j = 1:n
+                i != j && (G[i,j] = rand(rng, 0:1))
+            end
+        else                                                # 0/1/2 two-structure
+            for i = 1:n-1, j = i+1:n
+                G[i,j] = G[j,i] = rand(rng, 0:2)
+            end
+        end
+        p = shuffle(rng, 1:n)
+        @test repr(StrongModuleTree(G, copy(p))) ==
+              repr(StrongModuleTree(sparse(G), copy(p)))
+    end
+end


### PR DESCRIPTION
After #9 made the factorizing permutation linear in a sparse input, building the
tree from it was **99% of what a sparse symmetric graph costs**, and the cutter
search was 99% of *that*. This finishes the symmetric path.

## The change

The cutter search scans the permutation for the first and last vertex related
differently to the two ends of a consecutive pair. That looks at every place
before the cutter whether or not anything is there — Θ(n) per pair, Θ(n²) over
the permutation, on an input of size Θ(n + m).

The cutters are exactly the places where the two ends' relations differ, so
listing each vertex's relations in permutation order and merging the two lists
finds the first and last without looking anywhere else. One counting sort puts
every list in place order; the merges are Θ(n + m).

## Two methods, not a replacement

I first wrote this as a straight replacement, on the reasoning that the merge
can never be worse than the scan — it stops at the first cutter too, and the
places it steps over are a subset of the places the scan steps over. That is
true of the merge and false of the change, because the merge has to **build** the
lists first, and that build costs the size of the representation. On a dense
matrix the build alone is Θ(n²), against a scan that on a graph with edges
everywhere usually stops at the first place it looks:

| dense random graph | before | merge for everything |
| ---: | ---: | ---: |
| n = 3200 | 0.0011s | 1.2903s — **1170× slower** |

So the scan stays for matrices that store every pair, and the merge is for
matrices that store only the relations there are. Each is linear in the
representation it serves. (My earlier analysis on #3 said this — "wants both
paths, not a replacement" — and I talked myself out of it on reasoning instead
of measurement.)

## Effect

Building the strong module tree of a graph with m ≈ 3n, given as a
`SparseMatrixCSC`, and cost per word of that representation:

| n | before | after | ns/word before | ns/word after |
| ---: | ---: | ---: | ---: | ---: |
| 400 | 0.0026s | 0.0006s | 954.7 | 199.5 |
| 1600 | 0.0333s | 0.0022s | 2,981.9 | 195.1 |
| 6400 | 0.5040s | 0.0098s | 11,255.6 | 218.3 |
| 25600 | 8.6379s | **0.0425s** | 48,204.9 | 237.1 |
| | | | ~n^2.0 | ~n^1.0 |

203× at n = 25,600, and flat per word over a 64× range. Dense input is
untouched — 0.0011s at n = 3200 before and after.

**The symmetric path is now linear in its input end to end, for both
representations.**

## Verification

* The cutters found are identical to the scan's — `op`, `cl`, `lc`, `uc` all
  equal — over 8000 (graph, representation) pairs spanning symmetric graphs,
  digraphs and 0/1/2-labelled two-structures.
* Dense and sparse take different methods now, so they have to agree: they do
  over 20,000 random graphs, and exhaustively over every symmetric graph on
  n ≤ 6 (33,864 of them).
* Trees identical to `master` over 3000 random graphs and digraphs.
* 900,000 random digraph permutations and 5,670,000 symmetric ones, all modular.
* `test/factorizing.jl` gains a representation-agreement check, verified to
  catch a cutter that ignores one of the two directions.

## One thing the exhaustive check turned up, which is not from this PR

Over all 4-vertex digraphs, dense and sparse disagree on 2 of 4096 — and
`master` disagrees on exactly the same two. The cause is upstream:

```julia
julia> S = sparse([3,3,4,1,2], [1,2,2,3,4], ones(Int,5), 4, 4);

julia> S[2,3], S[3,2]
(0, 1)

julia> S == transpose(S)
false

julia> issymmetric(S)
true          # and issymmetric(Matrix(S)) is false
```

`graph_factorizing_permutation` branches on `issymmetric`, so for those matrices
it takes the symmetric path for a digraph. Reproduces on 1.10, 1.12 and
1.14-DEV, for `Int`, `Float64` and `Bool`. Separate from this change; reporting
it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
