### PR TITLE
Do not trust issymmetric to tell a digraph from a graph

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -445,11 +445,32 @@ function digraph_factorizing_permutation(
     return leaves(h)
 end
 
+"""
+    is_symmetric(G)
+
+Whether `G` equals its own transpose.
+
+`LinearAlgebra.issymmetric` is not to be trusted here: on a sparse matrix it can
+report symmetry that is not there, because while looking for the mirror of a
+stored entry it can read past the end of the column it is searching and find an
+entry belonging to the next one. JuliaSparse/SparseArrays.jl#748, and #636
+before it, which was fixed only for the case of an entirely empty column.
+Getting this wrong runs the undirected algorithm on a digraph and returns a
+permutation that is not a factorizing permutation at all.
+
+Comparing against a materialized transpose is correct and costs the size of the
+representation: O(n + nnz) for a sparse matrix, which is in fact quicker than
+`issymmetric`, and O(n²) for a dense one, where `issymmetric` is both correct
+and allocation-free and so is left in place.
+"""
+is_symmetric(G::AbstractMatrix) = issymmetric(G)
+is_symmetric(G::SparseMatrixCSC) = G == permutedims(G)
+
 function graph_factorizing_permutation(G::AbstractMatrix)
     a, b = extrema(G)
     0 ≤ a ≤ b ≤ 1 ||
         error("factoring multi-color two-structures not supported")
-    issymmetric(G) ?
+    is_symmetric(G) ?
         symgraph_factorizing_permutation(G) :
         digraph_factorizing_permutation(G)
 end

--- a/test/factorizing.jl
+++ b/test/factorizing.jl
@@ -108,3 +108,31 @@ end
         @warn "non-modular permutation" G=first_failure[1] p=first_failure[2]
     @test failures == 0
 end
+
+# LinearAlgebra.issymmetric can report a sparse matrix symmetric when it is not
+# (JuliaSparse/SparseArrays.jl#748), and choosing the undirected algorithm for a
+# digraph on that basis returns a permutation that is not factorizing at all.
+# This is one of the matrices it gets wrong, and the exhaustive check below is
+# what turned it up: it is 2 of the 4096 digraphs on four vertices, so nothing
+# smaller than all of them was going to find it.
+@testset "symmetry is tested without trusting issymmetric" begin
+    G = [0 0 1 0
+         0 0 0 1
+         1 1 0 0
+         0 1 0 0]
+    @test G != transpose(G)
+    @test !GraphModularDecomposition.is_symmetric(sparse(G))
+    @test is_modular_permutation(G, graph_factorizing_permutation(sparse(G)))
+
+    disagreements = 0
+    pairs = [(i, j) for i = 1:4 for j = 1:4 if i != j]
+    for bits = 0:(2^length(pairs) - 1)
+        H = zeros(Int, 4, 4)
+        for (b, (i, j)) in enumerate(pairs)
+            (bits >> (b-1)) & 1 == 1 && (H[i,j] = 1)
+        end
+        repr(StrongModuleTree(H)) == repr(StrongModuleTree(sparse(H))) ||
+            (disagreements += 1)
+    end
+    @test disagreements == 0
+end


### PR DESCRIPTION
`graph_factorizing_permutation` picks between the undirected and the directed
algorithm with `issymmetric`, and `issymmetric` is wrong for some sparse
matrices:

```julia
julia> S = sparse([3,3,4,1,2], [1,2,2,3,4], ones(Int,5), 4, 4);

julia> S[2,3], S[3,2]
(0, 1)

julia> S == transpose(S)
false

julia> issymmetric(S)
true          # issymmetric(Matrix(S)) is false
```

`is_hermsym` follows a per-column cursor to find the mirror of a stored entry,
and can read past the end of the column it is searching and land on an entry
belonging to the next one. Here column 3 spans a single index, the cursor
reaches the one after it, which holds a row from column 4, and it concludes
`A[2,3]` is stored and matches. Filed upstream as
[JuliaSparse/SparseArrays.jl#748](https://github.com/JuliaSparse/SparseArrays.jl/issues/748);
#636 fixed only the case of an entirely empty column, and this reproduces on
1.10, 1.12 and nightly.

The consequence here is that a digraph gets handed to the undirected algorithm
and comes back with a permutation that is not a factorizing permutation at all.

## The fix

Compare against a materialized transpose. That costs the size of the
representation either way, and for a sparse matrix it is *quicker* than what it
replaces — 0.00345s against 0.00449s at n = 64,000 with m ≈ 3n — because what is
slow is the lazy `transpose`, not the comparison. Dense matrices keep
`issymmetric`, which is correct there and allocates nothing.

## Verification

* All **4096** digraphs on four vertices now agree between representations; two
  disagreed before.
* All **32,768** symmetric graphs on six vertices still agree.
* The regression test was checked against a copy of the source without the fix
  and does fail there. Worth noting that only the exhaustive assertion fires:
  the deterministic ones pass even unfixed, because the wrong algorithm happens
  to return a modular permutation for that particular graph. Nothing smaller
  than all 4096 finds this.

## Unrelated, found while sweeping for this

`digraph_factorizing_permutation` returns non-modular permutations for some
sparse-ish digraphs, at about 6 in 480,000 — on **both** representations, so it
is nothing to do with `issymmetric`. I bisected it across every commit back to
`f1c0ccf`, before any of the recent work, and it is present throughout. Filing
separately with a reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
