### PR TITLE
Order a degenerate node's children by what is outside it

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -433,13 +433,39 @@ function digraph_factorizing_permutation(
             o = Dict(x => i for (i, x) in enumerate(q))
             sort!(h.nodes, by=x->o[first_leaf(x)])
         else # 0/2-complete node
-            d = Dict()
-            c = (1:n)\leaves(h)
+            # No edges run between this node's children, or all of them are
+            # reciprocal, so which unions of children are modules of G is
+            # decided entirely outside the node: a union is a module exactly
+            # when its children relate identically to every outside vertex, in
+            # both directions. Group them by that, so each such union comes out
+            # contiguous.
+            #
+            # Both halves of this matter. Looking only at G[v,x], as this used
+            # to, misses unions that are separated by the other direction. And
+            # taking the relation from one leaf of a child misrepresents the
+            # child: being a module of H does not make it a module of G -- H
+            # records only whether a pair is joined, not which way -- so a
+            # child's own leaves can disagree, and then no leaf speaks for it.
+            # Such a child joins no union and is set aside.
+            outside = (1:n)\leaves(h)
+            signatures, groups, aside = Vector{Any}(), Vector{Any}(), []
             for x in h.nodes
-                i = first_leaf(x)
-                push!(get!(d, G[c,i], []), x)
+                L = leaves(x)
+                i = first(L)
+                signature = [(G[v,i], G[i,v]) for v in outside]
+                if all(G[v,y] == G[v,i] && G[y,v] == G[i,v] for y in L, v in outside)
+                    k = findfirst(isequal(signature), signatures)
+                    if k === nothing
+                        push!(signatures, signature)
+                        push!(groups, Any[x])
+                    else
+                        push!(groups[k], x)
+                    end
+                else
+                    push!(aside, x)
+                end
             end
-            h.nodes .= [x for v in values(d) for x in v]
+            h.nodes .= vcat([x for g in groups for x in g], aside)
         end
     end
     sort_leaves!(h)

--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -440,6 +440,18 @@ function digraph_factorizing_permutation(
             # both directions. Group them by that, so each such union comes out
             # contiguous.
             #
+            # This is the relation R_X of McConnell & de Montgolfier 2005,
+            # "Linear-time modular decomposition of directed graphs", lemma 10
+            # and step 4 of their algorithm 3: S ~ S' when N⁺(S) and N⁺(S')
+            # agree outside the node and N⁻(S) and N⁻(S') do too, taken over
+            # the children that are modules of G. Their labels for H are not
+            # these -- theirs number a reciprocal pair 1 and a one-way pair 2,
+            # H = Gs + Gd numbers them the other way round -- so their
+            # "0-complete and 1-complete" is this branch and their "2-complete"
+            # is the tournament branch above, which takes arbitrary
+            # representatives on the strength of their lemma 11. Representatives
+            # are sound there and not here, which is what went wrong.
+            #
             # Both halves of this matter. Looking only at G[v,x], as this used
             # to, misses unions that are separated by the other direction. And
             # taking the relation from one leaf of a child misrepresents the

--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -460,19 +460,19 @@ function digraph_factorizing_permutation(
             # child's own leaves can disagree, and then no leaf speaks for it.
             # Such a child joins no union and is set aside.
             outside = (1:n)\leaves(h)
-            signatures, groups, aside = Vector{Any}(), Vector{Any}(), []
+            # this path only ever sees 0/1 entries -- G .| G' and G .& G' above
+            # are bitwise and mean nothing otherwise -- so one number per
+            # outside vertex distinguishes all four ways a pair can be related
+            relation(x, v) = G[v,x] + 2G[x,v]
+            index = Dict{Vector{Int},Int}()
+            groups, aside = Vector{Any}[], Any[]
             for x in h.nodes
                 L = leaves(x)
                 i = first(L)
-                signature = [(G[v,i], G[i,v]) for v in outside]
-                if all(G[v,y] == G[v,i] && G[y,v] == G[i,v] for y in L, v in outside)
-                    k = findfirst(isequal(signature), signatures)
-                    if k === nothing
-                        push!(signatures, signature)
-                        push!(groups, Any[x])
-                    else
-                        push!(groups[k], x)
-                    end
+                signature = [relation(i, v) for v in outside]
+                if all(relation(y, v) == relation(i, v) for y in L, v in outside)
+                    k = get!(index, signature, length(groups) + 1)
+                    k > length(groups) ? push!(groups, Any[x]) : push!(groups[k], x)
                 else
                     push!(aside, x)
                 end

--- a/test/factorizing.jl
+++ b/test/factorizing.jl
@@ -164,3 +164,40 @@ end
               repr(StrongModuleTree(sparse(G), copy(p)))
     end
 end
+
+# Regression for #13. sort_leaves! orders the children of a degenerate node of
+# the H tree, and that order is what decides whether a module of G that is only
+# a *union of siblings* comes out contiguous. Here {4,5,7} is such a module: it
+# is a module of G, a weak module of the symmetric part, and a module of no tree
+# the algorithm builds, so nothing but the child order keeps it together.
+@testset "factorizing permutations: sibling unions (#13)" begin
+    G = [0 0 0 0 0 1 0
+         1 0 0 0 0 1 0
+         0 0 0 0 0 0 0
+         1 0 0 0 0 0 0
+         1 0 0 0 0 0 0
+         0 0 0 0 0 0 0
+         1 0 0 0 1 0 0]
+    @test is_module(G, [4, 5, 7])
+    @test is_module(G, [5, 7])
+    for rep in (G, sparse(G))
+        p = graph_factorizing_permutation(rep)
+        @test sort(p) == collect(1:7)
+        @test diff(sort([findfirst(isequal(x), p) for x in (4,5,7)])) == [1, 1]
+        @test is_modular_permutation(G, p)
+    end
+
+    # Breadth, but read the margin before trusting it: the defect turns up in
+    # about one sparse digraph in forty thousand, and this seed finds exactly
+    # one in twenty-five thousand. It is the graph above that is the real guard;
+    # this is here to catch anything of the same shape that is not that graph.
+    rng = MersenneTwister(7) # a private stream: see test/overlap.jl
+    failures = 0
+    for _ = 1:6_000
+        n = rand(rng, 5:9)
+        H = Int[i != j && rand(rng, Bool) for i = 1:n, j = 1:n] .* rand(rng, 0:1, n, n)
+        q = graph_factorizing_permutation(H)
+        sort(q) == collect(1:n) && is_modular_permutation(H, q) || (failures += 1)
+    end
+    @test failures == 0
+end


### PR DESCRIPTION
Fixes #13.

## What was wrong

`digraph_factorizing_permutation` returned permutations in which a strong module
was not contiguous. On the seven-vertex graph now in `test/factorizing.jl`, the
module `{4,5,7}` came back at positions 2, 5 and 6.

The pipeline builds the tree of `H = Gs + Gd`, which records whether each pair is
joined and by how many directions, but not *which way round*. Every module of
`G` is a module of `H`, so no module of `G` ever straddles a node of that tree —
the tree's shape is never the problem. What is left is the **child order** of its
degenerate nodes, where `H` permits any order and `G` does not. That is exactly
what `sort_leaves!` is for, and it was getting it wrong two ways at once.

For a node whose children have no edges between them (or only reciprocal ones),
which unions of children are modules of `G` is settled entirely *outside* the
node: a union is a module exactly when its children relate identically to every
outside vertex, **in both directions**. The old key was `G[c,i]` — one
direction, and `i` a single leaf of the child.

**One direction is not enough.** In the graph above the node is `{2,4,5,6,7}`
with children `{4}`, `{2,6}`, `{5,7}`; the outside is `{1,3}`; and `G[c,i]` is
`[0,0]` for all three, so they stayed in the order they arrived. What separates
them is `4→1`, `5→1`, `7→1` against `6↛1` — the direction the key never reads.

**One leaf cannot stand for a child.** A child of the `H` tree need not be a
module of `G`: `{2,6}` is a module of `H`, since 1 is joined to both, and is not
a module of `G`, since `2→1` while `1→6`. Keyed on vertex 2 it looks identical to
`{4}` and `{5,7}`; keyed on vertex 6 it does not — the answer depended on which
leaf happened to be first. Such a child belongs to no union at all, and is now
set aside rather than given a representative it does not have.

## Verification

* **1,440,000 permutations** at n = 3…10, dense and sparse, over four
  generators — uniformly random digraphs, sparse ones, tournaments (which take
  the *other* branch of `sort_leaves!`), and digraphs with a planted module — no
  non-modular permutation.
* The same sweep against the code without this fix reports **8**, every one from
  the sparse generator. That is why this went unnoticed for so long: uniformly
  random digraphs never get sparse enough to produce the shape, and I had run
  900,000 of those earlier without a single failure.
* **The tree is unchanged wherever it was right.** Over 40,000 sparse digraphs
  exactly one tree differs from before, and it is the one whose permutation was
  not a factorizing permutation.
* The regression test was run against a copy of the source without the fix and
  does fail there.

## A note on the sweep in the test

The deterministic seven-vertex graph is the real guard. The seeded sweep beside
it is breadth, and its margin is thin — the defect appears in about one sparse
digraph in forty thousand, and that seed finds exactly one in twenty-five
thousand. The comment says so, so nobody later mistakes a passing sweep for
evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
