### PR TITLE
Make a node of many twins cheap to take apart

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -41,6 +41,27 @@ function neighbors(G::SparseMatrixCSC, x::Integer)
     (rows[k] for k in nzrange(G, x) if rows[k] != x && !iszero(vals[k]))
 end
 
+"""
+    is_symmetric(G)
+
+Whether `G` equals its own transpose.
+
+`LinearAlgebra.issymmetric` is not to be trusted here: on a sparse matrix it can
+report symmetry that is not there, because while looking for the mirror of a
+stored entry it can read past the end of the column it is searching and find an
+entry belonging to the next one. JuliaSparse/SparseArrays.jl#748, and #636
+before it, which was fixed only for the case of an entirely empty column.
+Getting this wrong runs the undirected algorithm on a digraph and returns a
+permutation that is not a factorizing permutation at all.
+
+Comparing against a materialized transpose is correct and costs the size of the
+representation: O(n + nnz) for a sparse matrix, which is in fact quicker than
+`issymmetric`, and O(n²) for a dense one, where `issymmetric` is both correct
+and allocation-free and so is left in place.
+"""
+is_symmetric(G::AbstractMatrix) = issymmetric(G)
+is_symmetric(G::SparseMatrixCSC) = G == permutedims(G)
+
 include("StrongModuleTrees.jl")
 using .StrongModuleTrees
 using .StrongModuleTrees: TreeIndex, containing_node, parent_index
@@ -253,44 +274,56 @@ function symgraph_factorizing_permutation(
             p = next_part()
             p == 0 && return false
             x = first_pivot[p] != 0 ? first_pivot[p] : elems[lo[p]]
-            for y in neighbors(G, x)
-                in_splitter[y] = true
-            end
-            A, N = Int[], Int[]
-            for j = lo[p]:hi[p]
-                y = elems[j]
-                y == x && continue
-                push!(in_splitter[y] ? A : N, y)
-            end
-            for y in neighbors(G, x)
-                in_splitter[y] = false
-            end
-            # rewrite p's range as the neighbours of x, then x, then the rest,
-            # and give each of the three a part of its own
-            j = lo[p]
-            for y in A
-                elems[j], pos[y] = y, j
-                j += 1
-            end
-            elems[j], pos[x] = x, j
-            xj = j
-            j += 1
-            for y in N
-                elems[j], pos[y] = y, j
-                j += 1
-            end
+            first_pivot[p] = 0 # p is about to stop being the part it was
+            # Split p into the neighbours of x, then x, then the rest, by moving
+            # only x and its neighbours to the front of p's range. Whatever is
+            # left is already in place and becomes the third part, so this costs
+            # O(deg x) rather than O(|p|).
+            #
+            # That matters because a part whose vertices are all twins can never
+            # be refined, so this loop is what takes it apart, one vertex per
+            # call. A star's leaves are such a part, and scanning it each time
+            # made a graph with n-1 edges cost Θ(n²).
             l, h = lo[p], hi[p]
-            nparts -= 1 # p is replaced by the parts made below
-            pa = isempty(A) ? 0 : new_part!(l, l + length(A) - 1)
+            cursor = l
+            for y in neighbors(G, x)
+                (y != x && part[y] == p) || continue
+                j = pos[y]
+                u = elems[cursor]
+                elems[j], pos[u] = u, j
+                elems[cursor], pos[y] = y, cursor
+                cursor += 1
+            end
+            j = pos[x] # x sits at or after the neighbours, never among them
+            u = elems[cursor]
+            elems[j], pos[u] = u, j
+            elems[cursor], pos[x] = x, cursor
+            xj = cursor
+            na, nn = xj - l, h - xj
+            # the old number stays with the larger side, so only the smaller
+            # side's vertices are relabelled
             px = new_part!(xj, xj)
-            pn = isempty(N) ? 0 : new_part!(xj + 1, h)
-            for q in (pa, px, pn), j = (q == 0 ? (1:0) : lo[q]:hi[q])
-                part[elems[j]] = q
+            part[x] = px
+            pa = pn = 0
+            if na > 0 && nn > 0
+                if na >= nn
+                    pa = p; lo[p], hi[p] = l, xj - 1
+                    pn = new_part!(xj + 1, h)
+                    for j = xj+1:h; part[elems[j]] = pn; end
+                else
+                    pn = p; lo[p], hi[p] = xj + 1, h
+                    pa = new_part!(l, xj - 1)
+                    for j = l:xj-1; part[elems[j]] = pa; end
+                end
+            elseif na > 0
+                pa = p; lo[p], hi[p] = l, xj - 1
+            else
+                pn = p; lo[p], hi[p] = xj + 1, h
             end
             drop_pivot!(p)
             mod_pos[p] != 0 && (mod_pos[p] = 0; nmodules -= 1)
             center = x
-            small, large = length(A) <= length(N) ? (pa, pn) : (pn, pa)
+            small, large = na <= nn ? (pa, pn) : (pn, pa)
             small != 0 && push_pivot!(small)
             large != 0 && push_module!(large)
         else
@@ -483,27 +516,6 @@ function digraph_factorizing_permutation(
     sort_leaves!(h)
     return leaves(h)
 end
-
-"""
-    is_symmetric(G)
-
-Whether `G` equals its own transpose.
-
-`LinearAlgebra.issymmetric` is not to be trusted here: on a sparse matrix it can
-report symmetry that is not there, because while looking for the mirror of a
-stored entry it can read past the end of the column it is searching and find an
-entry belonging to the next one. JuliaSparse/SparseArrays.jl#748, and #636
-before it, which was fixed only for the case of an entirely empty column.
-Getting this wrong runs the undirected algorithm on a digraph and returns a
-permutation that is not a factorizing permutation at all.
-
-Comparing against a materialized transpose is correct and costs the size of the
-representation: O(n + nnz) for a sparse matrix, which is in fact quicker than
-`issymmetric`, and O(n²) for a dense one, where `issymmetric` is both correct
-and allocation-free and so is left in place.
-"""
-is_symmetric(G::AbstractMatrix) = issymmetric(G)
-is_symmetric(G::SparseMatrixCSC) = G == permutedims(G)
 
 function graph_factorizing_permutation(G::AbstractMatrix)
     a, b = extrema(G)

--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -55,9 +55,16 @@ Getting this wrong runs the undirected algorithm on a digraph and returns a
 permutation that is not a factorizing permutation at all.
 
 Comparing against a materialized transpose is correct and costs the size of the
-representation: O(n + nnz) for a sparse matrix, which is in fact quicker than
-`issymmetric`, and O(n²) for a dense one, where `issymmetric` is both correct
-and allocation-free and so is left in place.
+representation: O(n + nnz) for a sparse matrix and O(n²) for a dense one, where
+`issymmetric` is both correct and allocation-free and so is left in place.
+
+There is no fast path through `issymmetric` first. Its `true` is the answer that
+cannot be trusted, so it would have to be checked again anyway; on a sparse
+matrix carrying stored zeros it can throw a `BoundsError` rather than return
+either answer, so it would need catching as well as checking; and at the
+densities a sparse matrix is worth having at all it is not the quicker of the
+two — around six entries per column the comparison below runs in 0.80 to 0.96
+of its time.
 """
 is_symmetric(G::AbstractMatrix) = issymmetric(G)
 is_symmetric(G::SparseMatrixCSC) = G == permutedims(G)

--- a/src/StrongModuleTrees.jl
+++ b/src/StrongModuleTrees.jl
@@ -5,8 +5,9 @@ export StrongModuleTree, strong_modules,
     nodes, node_count, parent_node, is_cograph
 
 using ..GraphModularDecomposition
-using ..GraphModularDecomposition: neighbors
-using SparseArrays: SparseMatrixCSC
+using ..GraphModularDecomposition: neighbors, is_symmetric
+using SparseArrays: SparseMatrixCSC, nonzeros, nzrange, rowvals
+using LinearAlgebra: checksquare
 
 ## core type definition ##
 
@@ -177,6 +178,96 @@ function find_cutters!(op, cl, lc, uc, G::SparseMatrixCSC, p::Vector{Int})
     end
 end
 
+## deciding a node's kind by counting crossings ##
+
+"""
+    crossing_kinds(G, v, root)
+
+For each node of the nested structure `root`, whether it is `:complete` and with
+which label, or `:prime` — or `nothing` when this cannot be answered this way.
+
+`classify_nodes` decides a node by comparing each of its children against each
+of the others. That is cheap for a prime node, which stops at the first pair
+that disagrees, and quadratic for a degenerate one, which never disagrees: a
+star's root has n-1 children with no edges among them, so a graph with n-1 edges
+costs Θ(n²).
+
+When the matrix is symmetric the question is only whether every pair of children
+is related the same way, and that can be counted instead of compared. A pair of
+vertices crosses between two children at exactly one node — the lowest one
+holding both of them — so a single pass over the stored entries gives every node
+the number of crossings it has and whether they all carry one label. Against the
+number of pairs that could cross, which the children's sizes give, that decides
+the node: none crossing means complete on the label of a non-edge, all crossing
+under one label means complete on that label, and anything else is prime.
+
+Only worth it for a matrix that stores its edges: reading a dense one costs the
+Θ(n²) this is trying to avoid, and there Θ(Σk²) is no worse than the input.
+"""
+function crossing_kinds(G::SparseMatrixCSC, v::AbstractVector{<:Integer}, root::Vector)
+    n = length(v)
+    (checksquare(G) == n && sort(v) == 1:n && is_symmetric(G)) || return nothing
+
+    place = Vector{Int}(undef, n)
+    for (i, x) in enumerate(v)
+        place[x] = i
+    end
+
+    # index the nodes: where each one starts and ends among the leaves, its
+    # parent, the sum of the squares of its children's sizes, and for each leaf
+    # the node directly above it
+    ids = IdDict{Any,Int}()
+    lo, hi, parent, sumsq = Int[], Int[], Int[], Int[]
+    holder = zeros(Int, n)
+    function index!(t::Vector, above::Int, at::Int)
+        push!(lo, at); push!(hi, 0); push!(parent, above); push!(sumsq, 0)
+        i = length(lo)
+        ids[t] = i
+        for x in t
+            if x isa Vector
+                at = index!(x, i, at)
+                j = ids[x]
+                sumsq[i] += (hi[j] - lo[j] + 1)^2
+            else
+                holder[at] = i
+                sumsq[i] += 1
+                at += 1
+            end
+        end
+        hi[i] = at - 1
+        return at
+    end
+    index!(root, 0, 1)
+
+    # every stored entry crosses at the lowest node holding both its ends
+    crossings = zeros(Int, length(lo))
+    label = fill(-2, length(lo)) # -2 nothing yet, -1 more than one label
+    rows, vals = rowvals(G), nonzeros(G)
+    for column = 1:n, k in nzrange(G, column)
+        row = rows[k]
+        row < column && !iszero(vals[k]) || continue # each pair once
+        a, b = minmax(place[row], place[column])
+        i = holder[a]
+        while hi[i] < b
+            i = parent[i]
+        end
+        crossings[i] += 1
+        label[i] = label[i] == -2 || label[i] == vals[k] ? vals[k] : -1
+    end
+
+    kinds = IdDict{Any,Tuple{Symbol,Tuple}}()
+    for (t, i) in ids
+        possible = ((hi[i] - lo[i] + 1)^2 - sumsq[i]) ÷ 2
+        kinds[t] =
+            crossings[i] == 0 ? (:complete, (0, 0)) :
+            label[i] != -1 && crossings[i] == possible ?
+                (:complete, (label[i], label[i])) : (:prime, ())
+    end
+    return kinds
+end
+
+crossing_kinds(G::AbstractMatrix, v::AbstractVector, root::Vector) = nothing
+
 ## constructing StrongModuleTrees ##
 
 function StrongModuleTree(
@@ -303,6 +394,11 @@ function StrongModuleTree(
             x = t[i]
             nodes[i], leaf[i] = x isa Vector ? classify_nodes(x) : (x, x)
         end
+        # counted rather than compared, where counting applies
+        if kinds !== nothing
+            kind, edge = kinds[t]
+            return StrongModuleTree{T}(kind, edge, nodes), leaf[1]
+        end
         counts = zeros(Int, n)
         x, y = leaf[1], leaf[2]
         edge = (G[y,x], G[x,y])
@@ -351,6 +447,7 @@ function StrongModuleTree(
             pop!(s)
         end
     end
+    kinds = crossing_kinds(G, v, s[end])
     t, _ = classify_nodes(s[end])
     delete_weak_modules!(t)
     return t


### PR DESCRIPTION
The last two quadratics in the symmetric path, both on graphs made of twins.

## Taking apart a node of twins

A star's leaves are all twins, and so are the halves of a perfect matching. Such
a part can never be refined — nothing distinguishes its members — so
`init_partition!` is what takes it apart, one vertex per call. It scanned the
whole part each time and then relabelled every element of it, so a graph with
n−1 edges cost Θ(n²).

It now splits the part by moving only `x` and its neighbours to the front of its
range: whatever is left is already in place and becomes the third part, and the
old part number stays with the larger of the two sides so only the smaller side
is relabelled. O(deg x) rather than O(|p|).

**I had this one wrong until I profiled it.** I opened this branch to fix
`classify_nodes`, on the reasoning that a node with n−1 children costs Θ(k²).
That reasoning is correct and it was not the bottleneck: rewriting it bought
10%, and the profile put **803 of 805 samples in `init_partition!`**.

## Deciding a node without comparing every pair

`classify_nodes` decides a node by comparing each child against each of the
others. That stops early on a prime node and runs to the end on a degenerate
one, so a node with n−1 children costs Θ(n²) however few edges there are.

For a symmetric matrix the question is only whether every pair of children is
related alike, and that can be counted instead. A pair of vertices crosses
between two children at exactly one node — the lowest one holding both of its
ends — so one pass over the stored entries gives every node its crossing count
and whether a single label covers them all. Against the crossings there could be,
which the children's sizes give: none means complete on the non-edge label, all
under one label means complete on that label, anything else is prime.

Only for a matrix that stores its edges. Reading a dense one costs the Θ(n²) this
is avoiding, and there Θ(Σk²) is no worse than the input, so dense keeps the
comparison — same split as the cutters in #11.

Neither change is sufficient alone: counting is worth 10% while `init_partition!`
dominates, and once `init_partition!` is fixed the pairwise comparison becomes
the next wall for exactly these graphs.

## Effect

Building the tree of a sparse graph, with cost per word of the representation:

| graph | n | before | after | ns/word after | slope |
| --- | ---: | ---: | ---: | ---: | ---: |
| star | 4000 | 0.8402s | **0.0082s** | 684.3 | 1.00 |
| perfect matching | 4000 | 0.4032s | **0.0081s** | 1017.5 | 0.97 |
| random m≈3n | 64000 | 0.1444s | 0.1491s | 332.8 | 1.19 |
| path | 64000 | 0.0422s | 0.0423s | 220.3 | 1.08 |

102× and 50×, flat per word. **Linear in a sparse input for all four shapes**,
where two of them were quadratic; the two that were already linear are unchanged.

## Verification

* Trees identical to `master` over 3000 random graphs and digraphs.
* Dense and sparse agree exhaustively over every digraph on n ≤ 4 and every
  symmetric graph on n ≤ 6 — the check that matters, since they now take
  different paths through both changes.
* 5,670,000 symmetric permutations; every graph on n ≤ 6 against every starting
  order (23,594,424 permutations); 1,440,000 digraph permutations over four
  generators. All modular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
