### PR TITLE
Decide a node's modularity from cutters, not from every leaf

### DIFF
--- a/src/GraphModularDecomposition.jl
+++ b/src/GraphModularDecomposition.jl
@@ -462,6 +462,7 @@ function digraph_factorizing_permutation(
     t = StrongModuleTree(Gd, pd)
     p = intersect_permutation(1:n, s, t)
     h = StrongModuleTree(H, p)
+    is_module = module_of(G, p, h) # nodes of h that are modules of G, or nothing
     function sort_leaves!(h)
         for x in h.nodes
             x isa StrongModuleTree && sort_leaves!(x)
@@ -507,10 +508,17 @@ function digraph_factorizing_permutation(
             index = Dict{Vector{Int},Int}()
             groups, aside = Vector{Any}[], Any[]
             for x in h.nodes
-                L = leaves(x)
-                i = first(L)
-                signature = [relation(i, v) for v in outside]
-                if all(relation(y, v) == relation(i, v) for y in L, v in outside)
+                i = first_leaf(x)
+                # whether this child is a module of G, and so has a relation to
+                # the outside that one of its leaves can speak for. Asking that
+                # by checking every leaf against every outside vertex is what
+                # this used to do, and it cost more than the rest of the
+                # decomposition together on a deep tree.
+                if is_module === nothing ?
+                       all(relation(y, v) == relation(i, v)
+                           for y in leaves(x), v in outside) :
+                       (!(x isa StrongModuleTree) || is_module[x])
+                    signature = [relation(i, v) for v in outside]
                     k = get!(index, signature, length(groups) + 1)
                     k > length(groups) ? push!(groups, Any[x]) : push!(groups[k], x)
                 else

--- a/src/StrongModuleTrees.jl
+++ b/src/StrongModuleTrees.jl
@@ -1,6 +1,6 @@
 module StrongModuleTrees
 
-export StrongModuleTree, strong_modules,
+export StrongModuleTree, strong_modules, module_of,
     leaves, leaf_count, first_leaf, last_leaf, rand_leaf,
     nodes, node_count, parent_node, is_cograph
 
@@ -268,6 +268,57 @@ end
 
 crossing_kinds(G::AbstractMatrix, v::AbstractVector, root::Vector) = nothing
 
+"""
+    module_of(G, p, h)
+
+For each node of `h`, whether its leaves are a module of `G` — or `nothing` when
+that cannot be answered this way.
+
+`h` is the tree of a coarser structure than `G`: `digraph_factorizing_permutation`
+builds it over `Gs + Gd`, which records whether a pair is joined but not which
+way round, so a node of `h` can be a module there and not in `G`. Deciding that
+by comparing every leaf of a node against every vertex outside it costs
+O(|node| · |outside|), which on a deep tree is worse than everything else in the
+pipeline put together.
+
+McConnell & de Montgolfier 2005, lemma 12: a node is a module of `G` exactly
+when no cutter, taken in `G`, of a consecutive pair inside it lies outside it.
+The cutters of consecutive pairs come from the same merge used to build the tree,
+and fold up the tree in one pass, so this is O(1) a node afterwards.
+"""
+function module_of(G::SparseMatrixCSC, p::Vector{Int}, h::StrongModuleTree)
+    n = length(p)
+    checksquare(G) == n && sort(p) == 1:n || return nothing
+    pos = zeros(Int, n)
+    for (k, v) in enumerate(p)
+        pos[v] = k
+    end
+    relations = Relations(G, p, pos)
+    locut, hicut = fill(typemax(Int), n), zeros(Int, n)
+    for j = 1:n-1
+        i = lower_cutter(relations, j); i != 0 && (locut[j] = i)
+        i = upper_cutter(relations, j); i != 0 && (hicut[j] = i)
+    end
+    answer = IdDict{Any,Bool}()
+    # returns where the node ends, and the extreme cutters of the pairs inside it
+    function fold(x, at::Int)
+        x isa StrongModuleTree || return at + 1, typemax(Int), 0
+        first = at
+        low, high = typemax(Int), 0
+        for (i, c) in enumerate(x.nodes)
+            i > 1 && (low = min(low, locut[at-1]); high = max(high, hicut[at-1]))
+            at, l, h = fold(c, at)
+            low, high = min(low, l), max(high, h)
+        end
+        answer[x] = low >= first && high <= at - 1
+        return at, low, high
+    end
+    fold(h, 1)
+    return answer
+end
+
+module_of(G::AbstractMatrix, p::Vector{Int}, h::StrongModuleTree) = nothing
+
 ## constructing StrongModuleTrees ##
 
 function StrongModuleTree(
@@ -504,13 +555,21 @@ rand_leaf(t::StrongModuleTree) = rand_leaf(rand(t.nodes))
 rand_leaf(v::Vector) = rand_leaf(last(v))
 rand_leaf(x::Any) = x
 
-function leaves(t::StrongModuleTree{T}) where T
-    L = T[]
+# Collected into one buffer rather than by concatenating each child's leaves
+# into the parent's. Concatenating rebuilds every subtree once per level above
+# it, so a single call costs O(size · depth) and asking every node of a deep
+# tree for its leaves -- which is what strong_modules does -- costs far more
+# than the leaves are worth. Theorem 8 of McConnell & de Montgolfier 2005 bounds
+# the leaves of all the strong modules together by 2m + 3n, so gathering them
+# should cost the size of the graph and no more.
+function leaves!(L::Vector, t::StrongModuleTree)
     for x in t.nodes
-        append!(L, leaves(x))
+        x isa StrongModuleTree ? leaves!(L, x) : push!(L, x)
     end
     return L
 end
+
+leaves(t::StrongModuleTree{T}) where {T} = leaves!(T[], t)
 leaves(x::Any) = [x]
 
 function nodes!(v::Vector{StrongModuleTree{T}}, t::StrongModuleTree{T}) where T


### PR DESCRIPTION
A digraph whose symmetric part has a module tree of depth Θ(n) took **12.79s at
n = 2000**, and its cost per word of input rose from 1400 to 6400 as it grew
rather than staying put. It is **1.60s** now, flat at about 600–790 ns/word.

Two things were paying for that, and neither was the one I predicted.

## The check I added in #14

`sort_leaves!` asks, of each child of a degenerate node, whether it is a module
of `G` and not merely of `H`. Since #14 it asked by comparing **every leaf of the
child against every vertex outside the node** — O(|child| · |outside|), which on
a deep tree costs more than the rest of the decomposition put together.

McConnell & de Montgolfier 2005, lemma 12: a node is a module of `G` exactly when
no cutter — taken in `G`, not in `H` — of a consecutive pair inside it lies
outside it. Those consecutive-pair cutters are what the tree was built from in
#11, they fold up the tree in a single pass, and the question is O(1) per node
afterwards.

## `leaves` rebuilding each subtree once per level

`leaves` gathered a node's leaves by concatenating each child's into the
parent's, with `leaves(x::Any) = [x]` allocating per leaf. So one call cost
O(size · depth), and `strong_modules` asks every node. Collecting into a single
buffer makes it O(size).

## A correction to #3

Theorem 8 of the same paper bounds the leaves of all strong modules together by
`2m + 3n`. **I had `strong_modules` recorded on #3 as Θ(n · depth) and as the
thing capping the linear-time overlap components from #4. That was wrong.** A
deep module tree forces a dense graph — a nested chain of strong modules of sizes
2…n has Σ|M| = Θ(n²), and Σ|M| ≤ 2m+3n — so the module sets are O(n + m) and were
never the bound. Measured against that bound, Σ|M|/(n+m) ≤ 1.00 across random,
star, path, nested and dense graphs. I will correct the issue.

## Effect

| n | arcs | before | after | ns/word after |
| ---: | ---: | ---: | ---: | ---: |
| 250 | 16,937 | 0.0476s | 0.0204s | 598 |
| 500 | 67,930 | 0.3603s | 0.0824s | 604 |
| 1000 | 236,738 | 1.9210s | 0.3687s | 777 |
| 2000 | 1,012,758 | **12.7856s** | **1.5975s** | 788 |

## Verification

* The cutter criterion agrees with comparing every leaf against every outside
  vertex on **all 44,534 nodes** of the trees of 30,000 random digraphs — zero
  disagreements.
* Output identical to `master` over 4000 graphs and digraphs.
* 1,440,000 digraph permutations over four generators; 5,670,000 symmetric ones;
  every graph on n ≤ 6 against every starting order. All modular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w7XdHqa7ynpy1nN1j19Qp
